### PR TITLE
Booting raspberry pi 5 and systemd + usb ncm drivers.

### DIFF
--- a/meta-edgeos/classes/partuuid.bbclass
+++ b/meta-edgeos/classes/partuuid.bbclass
@@ -1,51 +1,97 @@
+
 # partuuid.bbclass - Generate and cache UUIDs for partition references
+#
+# Exposes:
+#   EDGE_BOOT_PARTUUID
+#   EDGE_ROOT_PARTUUID
+#
+#   do_generate_partuuids: writes the chosen values to:
+#     - ${WORKDIR}/partuuids.conf
+#     - ${DEPLOY_DIR_IMAGE}/partuuids-${IMAGE_BASENAME}.conf
+#
+# Behavior:
+#   - Read PARTUUIDs from a cache file if it exists
+#   - Otherwise, generate fresh UUIDv4 values, write cache, and use them
+#
+PARTUUID_CACHE_DIR  ?= "${TOPDIR}/uuid-cache"
+PARTUUID_CACHE_FILE ?= "${PARTUUID_CACHE_DIR}/partuuids.conf"
+
+# Name of the audit file dropped next to images:
+PARTUUIDS_DEPLOY_NAME ?= "partuuids-${IMAGE_BASENAME}.conf"
 
 python __anonymous() {
-    import uuid
-    import os
-    
-    # Use build directory for caching UUIDs to ensure consistency within a build
-    build_dir = d.getVar('TOPDIR')
-    uuid_cache_dir = build_dir + '/uuid-cache'
-    uuid_cache_file = uuid_cache_dir + '/partuuids.conf'
-    
-    # Ensure cache directory exists
-    if not os.path.exists(uuid_cache_dir):
-        os.makedirs(uuid_cache_dir)
-    
-    # Try to read existing cached UUIDs
+    import os, uuid
+
+    cache_dir  = d.getVar('PARTUUID_CACHE_DIR')
+    cache_file = d.getVar('PARTUUID_CACHE_FILE')
+
+    # Ensure cache dir exists (safe at parse-time)
+    if not os.path.isdir(cache_dir):
+        os.makedirs(cache_dir, exist_ok=True)
+
     boot_uuid = None
     root_uuid = None
-    
-    if os.path.exists(uuid_cache_file):
+
+    # try to read from the cache
+    if os.path.exists(cache_file):
         try:
-            with open(uuid_cache_file, 'r') as f:
-                content = f.read()
-                for line in content.split('\n'):
+            with open(cache_file, 'r') as f:
+                for line in f:
                     if line.startswith('EDGE_BOOT_PARTUUID='):
                         boot_uuid = line.split('=', 1)[1].strip()
                     elif line.startswith('EDGE_ROOT_PARTUUID='):
                         root_uuid = line.split('=', 1)[1].strip()
-        except:
-            pass
-    
-    # Generate new UUIDs if not found in cache
+        except Exception as e:
+            bb.warn(f"partuuids: failed to read cache: {e}")
+
     if not boot_uuid or not root_uuid:
+        # generate if missing and update the cache
         boot_uuid = str(uuid.uuid4())
         root_uuid = str(uuid.uuid4())
-        
-        # Cache the UUIDs for other recipes
         try:
-            with open(uuid_cache_file, 'w') as f:
-                f.write(f'EDGE_BOOT_PARTUUID={boot_uuid}\n')
-                f.write(f'EDGE_ROOT_PARTUUID={root_uuid}\n')
+            with open(cache_file, 'w') as f:
+                f.write(f"EDGE_BOOT_PARTUUID={boot_uuid}\n")
+                f.write(f"EDGE_ROOT_PARTUUID={root_uuid}\n")
+            bb.note(f"partuuids: generated & cached boot={boot_uuid} root={root_uuid}")
         except Exception as e:
-            bb.warn(f"Failed to cache UUIDs: {e}")
-    
-    # Set as BitBake variables
+            bb.warn(f"partuuids: failed to write cache: {e}")
+
+    # export the variables to datastore
     d.setVar('EDGE_BOOT_PARTUUID', boot_uuid)
     d.setVar('EDGE_ROOT_PARTUUID', root_uuid)
-    
-    bb.note(f'Using Boot PARTUUID: {boot_uuid}')
-    bb.note(f'Using Root PARTUUID: {root_uuid}')
-} 
+
+    # make the variables available to WIC as well
+    wicvars = (d.getVar('WICVARS') or '')
+    extra = ' EDGE_BOOT_PARTUUID EDGE_ROOT_PARTUUID'
+    if extra not in wicvars:
+        d.setVar('WICVARS', (wicvars + extra).strip())
+}
+
+python do_generate_partuuids() {
+    import os
+
+    boot_uuid = d.getVar('EDGE_BOOT_PARTUUID')
+    root_uuid = d.getVar('EDGE_ROOT_PARTUUID')
+
+    # helper file to be used if a shell task or external script wants to source the
+    # values instead of relying on BitBake variable expansion
+    work_conf = os.path.join(d.getVar('WORKDIR'), 'partuuids.conf')
+    with open(work_conf, 'w') as f:
+        f.write(f"EDGE_BOOT_PARTUUID={boot_uuid}\nEDGE_ROOT_PARTUUID={root_uuid}\n")
+
+    # audit file to be used if post-build tooling/CI needs to read
+    # the UUIDs from ${DEPLOY_DIR_IMAGE} without parsing BitBake logs
+    deploy_dir = d.getVar('DEPLOY_DIR_IMAGE')
+    deploy_name = d.getVar('PARTUUIDS_DEPLOY_NAME')
+    if deploy_dir and deploy_name:
+        os.makedirs(deploy_dir, exist_ok=True)
+        with open(os.path.join(deploy_dir, deploy_name), 'w') as f:
+            f.write(f"EDGE_BOOT_PARTUUID={boot_uuid}\nEDGE_ROOT_PARTUUID={root_uuid}\n")
+
+    bb.note(f"partuuids: using boot={boot_uuid} root={root_uuid}")
+}
+
+addtask generate_partuuids before do_configure after do_patch
+
+# re-run the task if these knobs change
+do_generate_partuuids[vardeps] += "EDGE_BOOT_PARTUUID EDGE_ROOT_PARTUUID PARTUUID_CACHE_FILE PARTUUIDS_DEPLOY_NAME"

--- a/meta-edgeos/conf/distro/edgeos.conf
+++ b/meta-edgeos/conf/distro/edgeos.conf
@@ -1,0 +1,17 @@
+
+require conf/distro/poky.conf
+
+DISTRO = "edgeos"
+DISTROOVERRIDES = "poky"
+
+DISTRO_NAME = "edgeOS Linux platform"
+DISTRO_VERSION = "v0.1.0"
+# DISTRO_CODENAME = "..."
+
+SDK_VENDOR = "-edgeossdk"
+SDK_VERSION = "${@d.getVar('DISTRO_VERSION')}"
+
+# MAINTAINER = "name <email>"
+
+# remove distro unnecessary feature(s)
+DISTRO_FEATURES:remove = "x11 wayland opengl opengles egl sysvinit ptest 3g"

--- a/meta-edgeos/conf/distro/edgeos.conf
+++ b/meta-edgeos/conf/distro/edgeos.conf
@@ -1,5 +1,6 @@
 
 require conf/distro/poky.conf
+require systemd.conf
 
 DISTRO = "edgeos"
 DISTROOVERRIDES = "poky"

--- a/meta-edgeos/conf/distro/systemd.conf
+++ b/meta-edgeos/conf/distro/systemd.conf
@@ -1,0 +1,20 @@
+
+# enable systemd (instead of sysvinit)
+# use systemd as PID 1
+DISTRO_FEATURES:append = " systemd usrmerge"
+DISTRO_FEATURES:remove = " sysvinit"
+
+# prevent the old sysvinit feature from being backfilled
+DISTRO_FEATURES_BACKFILL_CONSIDERED += " sysvinit"
+
+VIRTUAL-RUNTIME_init_manager = "systemd"
+
+# provide compatibility for packages that still ship SysV scripts
+# (optional)
+VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
+# VIRTUAL-RUNTIME_syslog = ""
+# VIRTUAL-RUNTIME_base-utils-syslog = ""
+
+# using '/home/root' as root user's home directory is not fully supported by
+# systemd as the code hardcodes '/root'
+ROOT_HOME = "/root"

--- a/meta-edgeos/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-edgeos/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,4 +1,10 @@
 inherit partuuid
 
 CMDLINE_ROOT_PARTITION:rpi = "PARTUUID=${EDGE_ROOT_PARTUUID}"
-CMDLINE_ROOTFS:rpi = "console=serial0,115200 console=tty1 root=${CMDLINE_ROOT_PARTITION} rootfstype=ext4 fsck.repair=yes rootwait"
+
+# Replace any existing root=... with PARTUUID
+CMDLINE_ROOTFS:remove = "root=[^ ]+"
+CMDLINE_ROOTFS:rpi = "console=serial0,115200 root=${CMDLINE_ROOT_PARTITION} rootfstype=ext4 fsck.repair=yes rootwait"
+
+# ensure values are materialized (audit file handy)
+do_deploy[depends] += "${PN}:do_generate_partuuids"

--- a/meta-edgeos/recipes-bsp/bootfiles/rpi-config_%.bbappend
+++ b/meta-edgeos/recipes-bsp/bootfiles/rpi-config_%.bbappend
@@ -1,0 +1,6 @@
+
+do_deploy:append() {
+    echo "enable_uart=1" >> "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt"
+    echo "dtoverlay=uart0" >> "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt"
+}
+

--- a/meta-edgeos/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-edgeos/recipes-core/base-files/base-files_%.bbappend
@@ -4,11 +4,14 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI:append = " file://fstab"
 
-do_install:append() { 
+do_install:append() {
     # Process fstab template with dynamic UUIDs from partuuid class
     install -m 0644 ${WORKDIR}/fstab ${D}${sysconfdir}/fstab
-    
+
     # Replace UUID placeholders with actual values
     sed -i 's/RPI_BOOT_UUID/${EDGE_BOOT_PARTUUID}/g' ${D}${sysconfdir}/fstab
     sed -i 's/RPI_ROOT_UUID/${EDGE_ROOT_PARTUUID}/g' ${D}${sysconfdir}/fstab
 }
+
+# Make UUID changes trigger rebuilds wherever they’re used
+do_install[vardeps] += "EDGE_BOOT_PARTUUID EDGE_ROOT_PARTUUID"

--- a/meta-edgeos/recipes-core/images/edgeos-image.bb
+++ b/meta-edgeos/recipes-core/images/edgeos-image.bb
@@ -9,16 +9,19 @@ WKS_FILES_PATH = "${THISDIR}/../../wic"
 WKS_FILE_DEPENDS += "gptfdisk"
 
 IMAGE_FEATURES += "ssh-server-openssh"
-IMAGE_INSTALL += "packagegroup-core-boot vim"
+IMAGE_INSTALL += " \
+    packagegroup-edgeos-base \
+    packagegroup-edgeos-kernel \
+    packagegroup-edgeos-uboot \
+    packagegroup-edgeos-wifi \
+    packagegroup-edgeos-debug \
+    "
 
 EXTRA_IMAGEDEPENDS += "rpi-cmdline"
 do_image_wic[depends] += "rpi-cmdline:do_deploy wic-tools:do_populate_sysroot e2fsprogs-native:do_populate_sysroot"
 
 # ensure the UUIDs task ran before building the .wic
 do_image_wic[depends] += "${PN}:do_generate_partuuids"
-
-EDGEOS_DEBUG ?= "1"
-EDGEOS_DEBUG_UART ?= "1"
 
 # A space-separated list of variable names that BitBake prints in the
 # “Build Configuration” banner at the start of a build.

--- a/meta-edgeos/recipes-core/images/edgeos-image.bb
+++ b/meta-edgeos/recipes-core/images/edgeos-image.bb
@@ -17,6 +17,10 @@ IMAGE_INSTALL += " \
     packagegroup-edgeos-debug \
     "
 
+# enable USB peripheral (gadget) support
+ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('EDGEOS_USB_GADGET') == '1', '1', '0')}"
+IMAGE_INSTALL += " ${@oe.utils.ifelse(d.getVar('EDGEOS_USB_GADGET') == '1', ' usb-gadget', '')}"
+
 EXTRA_IMAGEDEPENDS += "rpi-cmdline"
 do_image_wic[depends] += "rpi-cmdline:do_deploy wic-tools:do_populate_sysroot e2fsprogs-native:do_populate_sysroot"
 
@@ -25,4 +29,4 @@ do_image_wic[depends] += "${PN}:do_generate_partuuids"
 
 # A space-separated list of variable names that BitBake prints in the
 # “Build Configuration” banner at the start of a build.
-BUILDCFG_VARS += "EDGEOS_DEBUG EDGEOS_DEBUG_UART"
+BUILDCFG_VARS += "EDGEOS_DEBUG EDGEOS_DEBUG_UART EDGEOS_USB_GADGET"

--- a/meta-edgeos/recipes-core/images/edgeos-image.bb
+++ b/meta-edgeos/recipes-core/images/edgeos-image.bb
@@ -17,3 +17,9 @@ do_image_wic[depends] += "rpi-cmdline:do_deploy wic-tools:do_populate_sysroot e2
 # ensure the UUIDs task ran before building the .wic
 do_image_wic[depends] += "${PN}:do_generate_partuuids"
 
+EDGEOS_DEBUG ?= "1"
+EDGEOS_DEBUG_UART ?= "1"
+
+# A space-separated list of variable names that BitBake prints in the
+# “Build Configuration” banner at the start of a build.
+BUILDCFG_VARS += "EDGEOS_DEBUG EDGEOS_DEBUG_UART"

--- a/meta-edgeos/recipes-core/images/edgeos-image.bb
+++ b/meta-edgeos/recipes-core/images/edgeos-image.bb
@@ -3,9 +3,6 @@ LICENSE = "MIT"
 
 inherit core-image image_types_wic partuuid
 
-# Add our UUID variables to WICVARS so they're available to WKS file
-WICVARS:append = " EDGE_BOOT_PARTUUID EDGE_ROOT_PARTUUID"
-
 IMAGE_FSTYPES += "wic"
 WKS_FILE = "rpi-partuuid.wks"
 WKS_FILES_PATH = "${THISDIR}/../../wic"
@@ -16,3 +13,7 @@ IMAGE_INSTALL += "packagegroup-core-boot vim"
 
 EXTRA_IMAGEDEPENDS += "rpi-cmdline"
 do_image_wic[depends] += "rpi-cmdline:do_deploy wic-tools:do_populate_sysroot e2fsprogs-native:do_populate_sysroot"
+
+# ensure the UUIDs task ran before building the .wic
+do_image_wic[depends] += "${PN}:do_generate_partuuids"
+

--- a/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-base.bb
+++ b/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-base.bb
@@ -1,0 +1,29 @@
+
+PR = "r0"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+SUMMARY:${PN} = "Base support"
+RDEPENDS:${PN} = " \
+    packagegroup-core-boot \
+    packagegroup-base-extended \
+    coreutils \
+    libstdc++ \
+    util-linux \
+    connman \
+    tzdata \
+    zstd \
+    iproute2 \
+    vim \
+    "
+
+RDEPENDS:${PN}:append = " \
+    ${@oe.utils.ifelse( \
+        d.getVar('EDGEOS_DEBUG') == '1', \
+        ' \
+            e2fsprogs-mke2fs \
+        ', \
+        '' \
+        )} \
+    "

--- a/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-debug.bb
+++ b/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-debug.bb
@@ -1,0 +1,27 @@
+
+PR = "r0"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+SUMMARY:${PN} = "Debugging package group"
+RDEPENDS:${PN} = " \
+    ${@oe.utils.ifelse( \
+        d.getVar('EDGEOS_DEBUG') == '1', \
+        ' \
+            mmc-utils \
+            fio \
+            memtester \
+            gperftools \
+            bash \
+            rt-tests \
+            htop \
+            nfs-utils \
+            procps \
+            sysstat \
+            ldd \
+            bc  \
+        ', \
+        '' \
+        )} \
+    "

--- a/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-kernel.bb
+++ b/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-kernel.bb
@@ -1,0 +1,13 @@
+
+PR = "r0"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+SUMMARY:${PN} = "Kernel package group"
+RDEPENDS:${PN} = " \
+    kernel-module-option \
+    kernel-module-usb-wwan \
+    kernel-module-usbserial \
+    libubootenv \
+    "

--- a/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-uboot.bb
+++ b/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-uboot.bb
@@ -1,0 +1,10 @@
+
+PR = "r0"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+SUMMARY:${PN} = "U-Boot package group"
+RDEPENDS:${PN} = " \
+    u-boot-fw-utils \
+    "

--- a/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-wifi.bb
+++ b/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-wifi.bb
@@ -1,0 +1,22 @@
+
+PR = "r0"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+SUMMARY:${PN} = "WiFi package group"
+RDEPENDS:${PN} = " \
+    wireless-regdb-static \
+    libnl \
+    libnl-route \
+    "
+
+RDEPENDS:${PN}:append = "\
+    ${@oe.utils.ifelse( \
+        d.getVar('EDGEOS_DEBUG') == '1', \
+        ' \
+            iw \
+        ', \
+        '' \
+        )} \
+    "

--- a/meta-edgeos/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-edgeos/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,3 @@
+
+# make sure the systemd recipe builds the networkd subpackage
+PACKAGECONFIG:append = " networkd"

--- a/meta-edgeos/recipes-core/usb-gadget/files/10-usb0.network
+++ b/meta-edgeos/recipes-core/usb-gadget/files/10-usb0.network
@@ -1,0 +1,17 @@
+#/etc/systemd/network/10-usb0.network
+
+[Match]
+Name=usb0
+
+[Network]
+Address=192.168.7.1/24
+DHCPServer=yes
+ConfigureWithoutCarrier=yes
+
+[DHCPServer]
+PoolOffset=2
+PoolSize=1
+# Optional extras:
+# EmitRouter=yes
+# DNS=192.168.7.1
+# EmitDNS=yes

--- a/meta-edgeos/recipes-core/usb-gadget/files/99-usb-gadget-udc.rules
+++ b/meta-edgeos/recipes-core/usb-gadget/files/99-usb-gadget-udc.rules
@@ -1,0 +1,4 @@
+# /etc/udev/rules.d/99-usb-gadget-udc.rules
+
+SUBSYSTEM=="udc", ACTION=="add",    TAG+="systemd", ENV{SYSTEMD_WANTS}+="usb-gadget-bind@%k.service"
+SUBSYSTEM=="udc", ACTION=="remove", TAG+="systemd", ENV{SYSTEMD_WANTS}+="usb-gadget-unbind.service"

--- a/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget-bind@.service
+++ b/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget-bind@.service
@@ -1,0 +1,10 @@
+
+[Unit]
+Description=Bind USB Gadget to %I
+After=usb-gadget-prepare.service systemd-networkd.service
+Requires=usb-gadget-prepare.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/usb-gadget.sh bind %I
+ExecStartPost=/usr/libexec/usb0-force-up

--- a/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget-prepare.service
+++ b/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget-prepare.service
@@ -1,0 +1,17 @@
+
+[Unit]
+Description=Prepare USB Gadget (NCM-only)
+After=sysinit.target local-fs.target systemd-udevd.service
+Wants=systemd-udevd.service
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/usb-gadget.sh prepare
+# Ensure udev sees the UDC and runs our bind unit, even if UDC existed first
+ExecStartPost=/usr/bin/udevadm control --reload
+ExecStartPost=/usr/bin/udevadm trigger --subsystem-match=udc --action=add
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget-unbind.service
+++ b/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget-unbind.service
@@ -1,0 +1,8 @@
+
+[Unit]
+Description=Unbind USB Gadget
+After=usb-gadget.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/usb-gadget.sh unbind

--- a/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget.sh
+++ b/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# Hybrid USB Gadget (NCM-only) for Raspberry Pi 5 (Yocto)
+# Subcommands:
+#   prepare  - create configfs gadget (no bind)
+#   bind [UDC]   - bind to UDC (arg optional; auto-picks first if omitted)
+#   unbind  - unbind from UDC (leave gadget tree intact)
+#   destroy - unbind (if bound) and remove gadget tree
+#
+# Note: No IP address work here—let systemd-networkd handle usb0.
+
+set -eu
+
+G="/sys/kernel/config/usb_gadget/g1"
+CONF="c.1"
+FUNC_NCM="ncm.usb0"
+LANG="0x409"   # English (US) USB LANGID
+
+log() { echo "[usb-gadget] $*"; }
+
+mount_configfs() {
+  [ -d /sys/kernel/config/usb_gadget ] || mount -t configfs none /sys/kernel/config
+}
+
+udc_name() { ls /sys/class/udc 2>/dev/null | head -n1; }
+
+is_bound() { [ -f "$G/UDC" ] && [ -n "$(cat "$G/UDC" 2>/dev/null)" ]; }
+
+prepare() {
+  modprobe libcomposite 2>/dev/null || true
+  mount_configfs
+
+  if [ -d "$G" ]; then
+    log "gadget already prepared at $G"
+    return 0
+  fi
+
+  mkdir -p "$G"
+
+  # --- Device IDs (replace with your own VID/PID for production) ---
+  echo 0x1d6b > "$G/idVendor"      # placeholder!
+  echo 0x0104 > "$G/idProduct"     # composite ID; fine for NCM testing
+  echo 0x0200 > "$G/bcdUSB"
+  echo 0x0100 > "$G/bcdDevice"
+
+  # --- Strings ---
+  mkdir -p "$G/strings/$LANG"
+  echo "0123456789" > "$G/strings/$LANG/serialnumber"
+  echo "MyCompany"  > "$G/strings/$LANG/manufacturer"
+  echo "Pi5 NCM"    > "$G/strings/$LANG/product"
+
+  # --- One configuration ---
+  mkdir -p "$G/configs/$CONF"
+  echo 120 > "$G/configs/$CONF/MaxPower"
+  mkdir -p "$G/configs/$CONF/strings/$LANG"
+  echo "NCM-only" > "$G/configs/$CONF/strings/$LANG/configuration"
+
+  # --- NCM function ---
+  mkdir -p "$G/functions/$FUNC_NCM"
+  # Locally administered MACs (02:…)
+  echo "02:12:34:56:78:ca" > "$G/functions/$FUNC_NCM/dev_addr"
+  echo "02:12:34:56:78:cb" > "$G/functions/$FUNC_NCM/host_addr"
+  # Optional tuning:
+  # echo 5 > "$G/functions/$FUNC_NCM/qmult"
+
+  # --- Microsoft OS descriptors so Windows auto-binds UsbNcm ---
+  mkdir -p "$G/os_desc"
+  echo 1        > "$G/os_desc/use"
+  echo 0xbc     > "$G/os_desc/b_vendor_code"  # any non-zero value
+  echo MSFT100  > "$G/os_desc/qw_sign"
+  mkdir -p "$G/functions/$FUNC_NCM/os_desc/interface.ncm"
+  echo WINNCM   > "$G/functions/$FUNC_NCM/os_desc/interface.ncm/compatible_id"
+  ln -s "$G/configs/$CONF" "$G/os_desc/$CONF"
+
+  # --- Link function into the config (no bind here) ---
+  ln -s "$G/functions/$FUNC_NCM" "$G/configs/$CONF/"
+
+  log "gadget prepared (not bound)"
+}
+
+bind() {
+  [ -d "$G" ] || { log "ERROR: gadget not prepared; run '$0 prepare' first"; exit 1; }
+  local UDC="${1:-$(udc_name)}"
+  [ -n "$UDC" ] || { log "ERROR: no UDC found in /sys/class/udc (is dwc2 loaded?)"; exit 1; }
+
+  # If already bound to this UDC, nothing to do
+  if is_bound && [ "$(cat "$G/UDC")" = "$UDC" ]; then
+    log "already bound to $UDC"
+    return 0
+  fi
+
+  # If bound to a different UDC (unlikely), unbind first
+  is_bound && echo "" > "$G/UDC" || true
+
+  echo "$UDC" > "$G/UDC"
+  log "bound to $UDC"
+}
+
+unbind() {
+  [ -d "$G" ] || { log "no gadget present"; return 0; }
+  if is_bound; then
+    echo "" > "$G/UDC" || true
+    log "unbound"
+  else
+    log "already unbound"
+  fi
+}
+
+destroy() {
+  # Unbind if needed
+  unbind || true
+
+  [ -d "$G" ] || { log "nothing to destroy"; return 0; }
+
+  # Remove os_desc symlink to config first
+  rm -f "$G/os_desc/$CONF" 2>/dev/null || true
+
+  # Remove config -> function symlinks
+  find "$G/configs" -maxdepth 2 -type l -delete 2>/dev/null || true
+
+  # Remove function (drop its os_desc child first)
+  rmdir "$G/functions/$FUNC_NCM/os_desc/interface.ncm" 2>/dev/null || true
+  rmdir "$G/functions/$FUNC_NCM/os_desc"               2>/dev/null || true
+  rmdir "$G/functions/$FUNC_NCM"                       2>/dev/null || true
+
+  # Remove config strings & dirs
+  rmdir "$G/configs/$CONF/strings/$LANG" 2>/dev/null || true
+  rmdir "$G/configs/$CONF/strings"       2>/dev/null || true
+  rmdir "$G/configs/$CONF"               2>/dev/null || true
+  rmdir "$G/configs"                      2>/dev/null || true
+
+  # Remove strings dir
+  rmdir "$G/strings/$LANG" 2>/dev/null || true
+  rmdir "$G/strings"       2>/dev/null || true
+
+  # Remove os_desc dir
+  rmdir "$G/os_desc" 2>/dev/null || true
+
+  # If a webusb dir ever exists, drop it too (no file deletes)
+  rmdir "$G/webusb" 2>/dev/null || true
+
+  # Finally remove the gadget root
+  rmdir "$G" 2>/dev/null || true
+
+  log "gadget destroyed"
+}
+
+case "${1:-}" in
+  prepare) prepare ;;
+  bind)    shift || true; bind "${1:-}" ;;
+  unbind)  unbind ;;
+  destroy) destroy ;;
+  *) echo "Usage: $0 {prepare|bind [UDC]|unbind|destroy}"; exit 2 ;;
+esac

--- a/meta-edgeos/recipes-core/usb-gadget/files/usb0-force-up
+++ b/meta-edgeos/recipes-core/usb-gadget/files/usb0-force-up
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Bring usb0 administratively UP as soon as it exists.
+# Retries a little to avoid races with bind timing.
+
+set -eu
+
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+for i in $(seq 1 50); do
+  if [ -e /sys/class/net/usb0 ]; then
+    ip link set dev usb0 up || true
+    exit 0
+  fi
+  sleep 0.1
+done
+exit 0

--- a/meta-edgeos/recipes-core/usb-gadget/usb-gadget.bb
+++ b/meta-edgeos/recipes-core/usb-gadget/usb-gadget.bb
@@ -1,0 +1,67 @@
+
+SUMMARY = "USB ECM+RNDIS gadget setup for Raspberry Pi 5 (configfs)"
+DESCRIPTION = "Creates a composite USB Ethernet gadget (ECM + RNDIS) and configures systemd-networkd with DHCP."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://usb-gadget.sh \
+    file://usb-gadget-prepare.service \
+    file://usb-gadget-bind@.service \
+    file://usb-gadget-unbind.service \
+    file://99-usb-gadget-udc.rules \
+    file://10-usb0.network \
+    file://usb0-force-up \
+    "
+
+S = "${WORKDIR}"
+
+inherit systemd
+
+do_install() {
+    # main script
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/usb-gadget.sh ${D}${sbindir}
+
+    # helper that forces usb0 admin-UP
+    install -d ${D}${libexecdir}
+    install -m 0755 ${WORKDIR}/usb0-force-up ${D}${libexecdir}
+
+    # systemd units
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/usb-gadget-prepare.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/usb-gadget-bind@.service   ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/usb-gadget-unbind.service  ${D}${systemd_unitdir}/system
+
+    # udev rule
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/99-usb-gadget-udc.rules ${D}${sysconfdir}/udev/rules.d
+
+    # systemd-networkd config (Pi=192.168.7.1/24, host via DHCP=.2)
+    install -d ${D}${sysconfdir}/systemd/network
+    install -m 0644 ${WORKDIR}/10-usb0.network ${D}${sysconfdir}/systemd/network
+}
+
+# Enable only the prepare service; bind/unbind are started by udev when needed
+SYSTEMD_SERVICE:${PN} = "usb-gadget-prepare.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+RDEPENDS:${PN} += "udev kmod iproute2 systemd-networkd"
+
+FILES:${PN} += "\
+    ${sbindir}/usb-gadget.sh \
+    ${libexecdir}/usb0-force-up \
+    ${systemd_unitdir}/system/usb-gadget-prepare.service \
+    ${systemd_unitdir}/system/usb-gadget-bind@.service \
+    ${systemd_unitdir}/system/usb-gadget-unbind.service \
+    ${sysconfdir}/udev/rules.d/99-usb-gadget-udc.rules \
+    ${sysconfdir}/systemd/network/10-usb0.network \
+    "
+
+# the split package name 'systemd-networkd' isn’t present in Scarthgap
+# so we don't hard-require it
+RDEPENDS:${PN}:remove = " systemd-networkd"
+RDEPENDS:${PN} += " systemd"
+
+# future proof (no-op on Scarthgap, useful on branches that split it):
+# RRECOMMENDS:${PN} += " systemd-networkd"

--- a/meta-edgeos/recipes-support/htop/files/0001-Use-pkg-config.patch
+++ b/meta-edgeos/recipes-support/htop/files/0001-Use-pkg-config.patch
@@ -1,0 +1,47 @@
+From 0d49ee6416e389b9a7ba693588c2eaf129306a01 Mon Sep 17 00:00:00 2001
+From: Paul Barker <pbarker@toganlabs.com>
+Date: Sun, 5 Nov 2017 22:07:30 +0000
+Subject: [PATCH] htop: Update to v2.0.2
+
+We need to use pkg-config to find the ncurses library instead of the
+ncurses*-config applications.
+
+Signed-off-by: Paul Barker <pbarker@toganlabs.com>
+Signed-off-by: Robert Joslyn <robert.joslyn@redrectangle.org>
+
+Upstream-Status: Inappropriate [`ncurses*-config` can be used outside of OpenEmbedded]
+
+---
+ configure.ac | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index e4df238a..2a31b201 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -391,10 +391,10 @@ AC_ARG_ENABLE([unicode],
+               [],
+               [enable_unicode=yes])
+ if test "x$enable_unicode" = xyes; then
+-   HTOP_CHECK_SCRIPT([ncursesw6], [waddwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
+-    HTOP_CHECK_SCRIPT([ncursesw], [waddwstr], [HAVE_LIBNCURSESW], "ncursesw6-config",
+-     HTOP_CHECK_SCRIPT([ncursesw], [wadd_wch], [HAVE_LIBNCURSESW], "ncursesw5-config",
+-      HTOP_CHECK_SCRIPT([ncurses], [wadd_wch], [HAVE_LIBNCURSESW], "ncurses5-config",
++   HTOP_CHECK_SCRIPT([ncursesw6], [waddwstr], [HAVE_LIBNCURSESW], "pkg-config ncursesw6",
++    HTOP_CHECK_SCRIPT([ncursesw], [waddwstr], [HAVE_LIBNCURSESW], "pkg-config ncursesw6",
++     HTOP_CHECK_SCRIPT([ncursesw], [wadd_wch], [HAVE_LIBNCURSESW], "pkg-config ncursesw5",
++      HTOP_CHECK_SCRIPT([ncurses], [wadd_wch], [HAVE_LIBNCURSESW], "pkg-config ncurses5",
+        HTOP_CHECK_LIB([ncursesw6], [addnwstr], [HAVE_LIBNCURSESW],
+         HTOP_CHECK_LIB([ncursesw], [addnwstr], [HAVE_LIBNCURSESW],
+          HTOP_CHECK_LIB([ncurses], [addnwstr], [HAVE_LIBNCURSESW],
+@@ -416,8 +416,8 @@ if test "x$enable_unicode" = xyes; then
+    # (at this point we already link against a working ncurses library with wide character support)
+    AC_SEARCH_LIBS([keypad], [tinfow tinfo])
+ else
+-   HTOP_CHECK_SCRIPT([ncurses6], [wnoutrefresh], [HAVE_LIBNCURSES], [ncurses6-config],
+-    HTOP_CHECK_SCRIPT([ncurses], [wnoutrefresh], [HAVE_LIBNCURSES], [ncurses5-config],
++   HTOP_CHECK_SCRIPT([ncurses6], [wnoutrefresh], [HAVE_LIBNCURSES], [pkg-config ncurses6],
++    HTOP_CHECK_SCRIPT([ncurses], [wnoutrefresh], [HAVE_LIBNCURSES], [pkg-config ncurses5],
+      HTOP_CHECK_LIB([ncurses6],  [doupdate], [HAVE_LIBNCURSES],
+       HTOP_CHECK_LIB([ncurses],  [doupdate], [HAVE_LIBNCURSES],
+        HTOP_CHECK_LIB([curses],  [doupdate], [HAVE_LIBNCURSES],

--- a/meta-edgeos/recipes-support/htop/files/htoprc
+++ b/meta-edgeos/recipes-support/htop/files/htoprc
@@ -1,0 +1,26 @@
+# Beware! This file is rewritten by htop when settings are changed in the interface.
+# The parser is also very primitive, and not human-friendly.
+fields=0 48 17 18 38 39 40 2 46 47 49 1
+sort_key=46
+sort_direction=1
+hide_threads=0
+hide_kernel_threads=1
+hide_userland_threads=0
+shadow_other_users=0
+show_thread_names=1
+show_program_path=1
+highlight_base_name=1
+highlight_megabytes=1
+highlight_threads=1
+tree_view=1
+header_margin=1
+detailed_cpu_time=0
+cpu_count_from_zero=0
+update_process_names=0
+account_guest_in_cpu_meter=0
+color_scheme=0
+delay=15
+left_meters=AllCPUs Memory Swap
+left_meter_modes=1 1 1
+right_meters=Tasks LoadAverage Uptime
+right_meter_modes=2 2 2

--- a/meta-edgeos/recipes-support/htop/htop_%.bbappend
+++ b/meta-edgeos/recipes-support/htop/htop_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://htoprc"
+
+do_install:append() {
+  install -d ${D}${sysconfdir}
+  install -m 0644 ${WORKDIR}/htoprc ${D}${sysconfdir}/htoprc
+}


### PR DESCRIPTION
 ## Key Changes

  ### 🔄 Boot & Partition Handling
  - **Fixed PARTUUID implementation** to resolve boot failures where kernel couldn't mount rootfs
  - **Fixed alternate GPT header positioning** issue at end of disk
  - **Enhanced partuuid.bbclass** with proper UUID generation and validation (80 additions, 34 deletions)

  ### 🐧 Init System Migration
  - **Replaced sysvinit with systemd** as the primary init manager
  - **Added EdgeOS distro configuration** (`edgeos.conf`) with proper systemd features
  - **Configured systemd with usrmerge** and removed sysvinit from DISTRO_FEATURES

  ### 🔌 USB NCM Gadget Support
  - **Implemented complete USB NCM gadget stack** for ethernet-over-USB functionality
  - **Added configfs-based gadget management** via `usb-gadget.sh` script (153 lines)
  - **Created systemd services** for gadget lifecycle:
    - `usb-gadget-prepare.service` - Initialize gadget at boot
    - `usb-gadget-bind@.service` - Bind to UDC controller
    - `usb-gadget-unbind.service` - Clean unbind on shutdown
  - **Configured systemd-networkd** for automatic usb0 interface management with static IP (169.254.214.2/24)
  - **Added udev rules** for automatic UDC binding when hardware is detected

  ### 📦 Package Organization
  - **Modularized features into package groups**:
    - `packagegroup-edgeos-base` - Core system utilities
    - `packagegroup-edgeos-kernel` - Kernel modules and firmware
    - `packagegroup-edgeos-debug` - Development and debugging tools
    - `packagegroup-edgeos-wifi` - Wireless networking support
    - `packagegroup-edgeos-uboot` - U-Boot utilities

  ### 🛠️ Platform Enhancements
  - **Enabled UART0 console** on GPIO14/15 for serial debugging (`/dev/serial0`)
  - **Added debug image support** with comprehensive development tools
  - **Customized htop** with pre-configured layout for system monitoring
