### PR TITLE
Add EdgeOS system identity and build management

### DIFF
--- a/meta-edgeos/recipes-bsp/bootfiles/rpi-config_%.bbappend
+++ b/meta-edgeos/recipes-bsp/bootfiles/rpi-config_%.bbappend
@@ -2,5 +2,10 @@
 do_deploy:append() {
     echo "enable_uart=1" >> "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt"
     echo "dtoverlay=uart0" >> "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt"
+    
+    # Enable dwc2 for USB gadget support (conditional based on ENABLE_DWC2_PERIPHERAL)
+    if [ "${ENABLE_DWC2_PERIPHERAL}" = "1" ]; then
+        echo "dtoverlay=dwc2" >> "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/config.txt"
+    fi
 }
 

--- a/meta-edgeos/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-edgeos/recipes-core/base-files/base-files_%.bbappend
@@ -5,6 +5,23 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI:append = " file://fstab"
 
+# EdgeOS branding configuration
+EDGEOS_HOSTNAME ?= "edgeos-device"
+
+# Get git commit hash for build tracking (deterministic within same commit)
+# Falls back to "dev" if not in a git repo
+def get_git_hash(d):
+    import subprocess
+    try:
+        return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], 
+                                      cwd=d.getVar('TOPDIR')).decode('utf-8').strip()
+    except:
+        return "dev"
+
+# Use git commit hash for build ID by default
+# Can be overridden in local.conf with EDGEOS_BUILD_ID = "${DATETIME}" or any other value
+EDGEOS_BUILD_ID ?= "${@get_git_hash(d)}"
+
 do_install:append() {
     # Process fstab template with dynamic UUIDs from partuuid class
     install -m 0644 ${WORKDIR}/fstab ${D}${sysconfdir}/fstab
@@ -12,6 +29,13 @@ do_install:append() {
     # Replace UUID placeholders with actual values
     sed -i 's/RPI_BOOT_UUID/${EDGE_BOOT_PARTUUID}/g' ${D}${sysconfdir}/fstab
     sed -i 's/RPI_ROOT_UUID/${EDGE_ROOT_PARTUUID}/g' ${D}${sysconfdir}/fstab
+
+    # Set EdgeOS hostname
+    echo "${EDGEOS_HOSTNAME}" > ${D}${sysconfdir}/hostname
+
+    # Generate EdgeOS build ID file
+    echo "EdgeOS-${EDGEOS_BUILD_ID}" > ${D}${sysconfdir}/edgeos-build-id
+    chmod 644 ${D}${sysconfdir}/edgeos-build-id
 }
 
 # Make UUID changes trigger rebuilds wherever they’re used

--- a/meta-edgeos/recipes-core/edgeos-identity/edgeos-identity_1.0.bb
+++ b/meta-edgeos/recipes-core/edgeos-identity/edgeos-identity_1.0.bb
@@ -1,0 +1,35 @@
+SUMMARY = "EdgeOS Device Identity Management"
+DESCRIPTION = "Generates and manages unique device UUID for EdgeOS devices"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+SRC_URI = " \
+    file://generate-uuid.sh \
+    file://edgeos-identity.service \
+    "
+
+S = "${WORKDIR}"
+
+SYSTEMD_SERVICE:${PN} = "edgeos-identity.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    # Install UUID generation script
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/generate-uuid.sh ${D}${bindir}/
+
+    # Install systemd service
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/edgeos-identity.service ${D}${systemd_system_unitdir}/
+
+    # Create directory for UUID storage
+    install -d ${D}${sysconfdir}/edgeos
+}
+
+FILES:${PN} += "${bindir}/generate-uuid.sh"
+FILES:${PN} += "${systemd_system_unitdir}/edgeos-identity.service"
+FILES:${PN} += "${sysconfdir}/edgeos"
+
+RDEPENDS:${PN} = "bash util-linux-uuidgen"

--- a/meta-edgeos/recipes-core/edgeos-identity/files/edgeos-identity.service
+++ b/meta-edgeos/recipes-core/edgeos-identity/files/edgeos-identity.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=EdgeOS Device Identity Setup
+DefaultDependencies=no
+Before=sysinit.target
+After=local-fs.target
+ConditionPathExists=!/etc/edgeos/device-uuid
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/generate-uuid.sh
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=sysinit.target

--- a/meta-edgeos/recipes-core/edgeos-identity/files/generate-uuid.sh
+++ b/meta-edgeos/recipes-core/edgeos-identity/files/generate-uuid.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# EdgeOS Device UUID Generation Script
+# Generates a unique device UUID on first boot
+
+UUID_FILE="/etc/edgeos/device-uuid"
+UUID_DIR=$(dirname "$UUID_FILE")
+
+# Check if UUID already exists
+if [ -f "$UUID_FILE" ]; then
+    echo "Device UUID already exists: $(cat $UUID_FILE)"
+    exit 0
+fi
+
+# Create directory if it doesn't exist
+if [ ! -d "$UUID_DIR" ]; then
+    mkdir -p "$UUID_DIR"
+    chmod 755 "$UUID_DIR"
+fi
+
+# Generate new UUID
+NEW_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+# Write UUID to file
+echo "$NEW_UUID" > "$UUID_FILE"
+chmod 644 "$UUID_FILE"
+
+echo "Generated new device UUID: $NEW_UUID"
+
+# Also write to kernel log for debugging
+logger -t edgeos-identity "Generated device UUID: $NEW_UUID"

--- a/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-base.bb
+++ b/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-base.bb
@@ -16,6 +16,8 @@ RDEPENDS:${PN} = " \
     zstd \
     iproute2 \
     vim \
+    edgeos-identity \
+    edgeos-user \
     "
 
 RDEPENDS:${PN}:append = " \

--- a/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget.sh
+++ b/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget.sh
@@ -50,17 +50,31 @@ prepare() {
     echo 0x0200 > "$G/bcdUSB"
     echo 0x0100 > "$G/bcdDevice"
 
+    echo 0x02 > "$G/bDeviceClass"      # CDC composite class
+    echo 0x00 > "$G/bDeviceSubClass"
+    echo 0x00 > "$G/bDeviceProtocol"
+
+
     # --- Strings ---
     mkdir -p "$G/strings/$LANG"
-    echo "0123456789" > "$G/strings/$LANG/serialnumber"
-    echo "MyCompany"  > "$G/strings/$LANG/manufacturer"
-    echo "Pi5 NCM"    > "$G/strings/$LANG/product"
+    # Get device serial or use default
+    if [ -f /proc/device-tree/serial-number ]; then
+        SERIAL=$(cat /proc/device-tree/serial-number | tr -d '\0')
+    elif [ -f /etc/edgeos/device-uuid ]; then
+        SERIAL=$(cat /etc/edgeos/device-uuid | cut -c1-8)
+    else
+        SERIAL="0123456789"
+    fi
+    echo "$SERIAL" > "$G/strings/$LANG/serialnumber"
+    echo "EdgeOS"  > "$G/strings/$LANG/manufacturer"
+    echo "EdgeOS Device"    > "$G/strings/$LANG/product"
 
     # --- One configuration ---
     mkdir -p "$G/configs/$CONF"
     echo 250 > "$G/configs/$CONF/MaxPower"
     mkdir -p "$G/configs/$CONF/strings/$LANG"
     echo "NCM-only" > "$G/configs/$CONF/strings/$LANG/configuration"
+    echo 0x80 > "$G/configs/$CONF/bmAttributes" 
 
     # --- NCM function ---
     mkdir -p "$G/functions/$FUNC_NCM"

--- a/meta-edgeos/recipes-core/usb-gadget/usb-gadget.bb
+++ b/meta-edgeos/recipes-core/usb-gadget/usb-gadget.bb
@@ -19,18 +19,20 @@ S = "${WORKDIR}"
 inherit systemd
 
 do_install() {
-    # main script
+    # main script - install with EdgeOS branding
     install -d ${D}${sbindir}
-    install -m 0755 ${WORKDIR}/usb-gadget.sh ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/usb-gadget.sh ${D}${sbindir}/edgeos-usbgadget.sh
+    # Create compatibility symlink
+    ln -sf edgeos-usbgadget.sh ${D}${sbindir}/usb-gadget.sh
 
     # helper that forces usb0 admin-UP
     install -d ${D}${libexecdir}
     install -m 0755 ${WORKDIR}/usb0-force-up ${D}${libexecdir}
 
-    # systemd units
+    # systemd units - install with EdgeOS branding
     install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/usb-gadget-prepare.service ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/usb-gadget-unbind.service  ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/usb-gadget-prepare.service ${D}${systemd_unitdir}/system/edgeos-usbgadget-prepare.service
+    install -m 0644 ${WORKDIR}/usb-gadget-unbind.service  ${D}${systemd_unitdir}/system/edgeos-usbgadget-unbind.service
 
     # udev rule
     install -d ${D}${sysconfdir}/udev/rules.d
@@ -40,19 +42,34 @@ do_install() {
     # systemd-networkd config (Pi=192.168.7.1/24, host via DHCP=.2)
     install -d ${D}${sysconfdir}/systemd/network
     install -m 0644 ${WORKDIR}/10-usb0.network ${D}${sysconfdir}/systemd/network
+
+    # Update service files to reference the renamed script
+    sed -i 's|/usr/sbin/usb-gadget.sh|/usr/sbin/edgeos-usbgadget.sh|g' \
+        ${D}${systemd_unitdir}/system/edgeos-usbgadget-prepare.service
+    sed -i 's|/usr/sbin/usb-gadget.sh|/usr/sbin/edgeos-usbgadget.sh|g' \
+        ${D}${systemd_unitdir}/system/edgeos-usbgadget-unbind.service
+    
+    # Update udev rules to reference the renamed services
+    sed -i 's|usb-gadget-unbind.service|edgeos-usbgadget-unbind.service|g' \
+        ${D}${sysconfdir}/udev/rules.d/99-usb-gadget-udc.rules
+    
+    # Update logging in the script to show EdgeOS branding
+    sed -i 's|\[usb-gadget\]|[edgeos-usbgadget]|g' \
+        ${D}${sbindir}/edgeos-usbgadget.sh
 }
 
 # Enable only the prepare service; bind/unbind are started by udev when needed
-SYSTEMD_SERVICE:${PN} = "usb-gadget-prepare.service"
+SYSTEMD_SERVICE:${PN} = "edgeos-usbgadget-prepare.service"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 RDEPENDS:${PN} += "udev kmod iproute2 systemd-networkd"
 
 FILES:${PN} += "\
+    ${sbindir}/edgeos-usbgadget.sh \
     ${sbindir}/usb-gadget.sh \
     ${libexecdir}/usb0-force-up \
-    ${systemd_unitdir}/system/usb-gadget-prepare.service \
-    ${systemd_unitdir}/system/usb-gadget-unbind.service \
+    ${systemd_unitdir}/system/edgeos-usbgadget-prepare.service \
+    ${systemd_unitdir}/system/edgeos-usbgadget-unbind.service \
     ${sysconfdir}/udev/rules.d/90-usb0-up.rules \
     ${sysconfdir}/udev/rules.d/99-usb-gadget-udc.rules \
     ${sysconfdir}/systemd/network/10-usb0.network \

--- a/meta-edgeos/recipes-extended/edgeos-user/edgeos-user_1.0.bb
+++ b/meta-edgeos/recipes-extended/edgeos-user/edgeos-user_1.0.bb
@@ -1,0 +1,53 @@
+SUMMARY = "EdgeOS Default User Configuration"
+DESCRIPTION = "Creates the default 'edge' user with appropriate permissions for EdgeOS"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit useradd
+
+# Create edge user - simplified group list (non-existent groups cause failures)
+USERADD_PACKAGES = "${PN}"
+# Password 'edge' hash generated with: openssl passwd -6 -salt 5ixFr0sKRtsKKKhY edge
+USERADD_PARAM:${PN} = "-m -d /home/edge -s /bin/bash -G dialout,video,audio,users -p '\$6\$5ixFr0sKRtsKKKhY\$NBU4Np0LBKjFMFZ5BpJr8wLT5UvTpY1cVFGdUWMCs0m4UDGMTHlU2efR6Qfwq5BMtCq8wqN.RoZH/vEt/cuyE1' edge"
+
+do_install() {
+    # Create home directory structure
+    install -d -m 0755 ${D}/home/edge
+    install -d -m 0700 ${D}/home/edge/.ssh
+    
+    # Create default .bashrc
+    cat > ${D}/home/edge/.bashrc << 'EOF'
+# EdgeOS user environment
+export PS1='\u@\h:\w\$ '
+export PATH=$PATH:/usr/local/bin:/usr/sbin:/sbin
+
+# Aliases
+alias ll='ls -la'
+alias l='ls -CF'
+
+# EdgeOS specific
+if [ -f /etc/edgeos-build-id ]; then
+    export EDGEOS_BUILD=$(cat /etc/edgeos-build-id)
+fi
+
+if [ -f /etc/edgeos/device-uuid ]; then
+    export EDGEOS_UUID=$(cat /etc/edgeos/device-uuid)
+fi
+EOF
+    
+    # Set proper ownership
+    chown -R 1000:1000 ${D}/home/edge
+}
+
+pkg_postinst_ontarget:${PN}() {
+    # Add sudoers entry for edge user on target only
+    if [ -d /etc/sudoers.d ]; then
+        echo "edge ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/edge
+        chmod 0440 /etc/sudoers.d/edge
+    fi
+}
+
+FILES:${PN} += "/home/edge"
+
+# Ensure sudo is available
+RDEPENDS:${PN} = "sudo bash"


### PR DESCRIPTION
#18 
Implements EdgeOS-specific branding and identity management features:

- Default hostname configuration (edgeos-device)
- Build ID system (/etc/edgeos-build-id) using git commit hash
- Device UUID generation on first boot (/etc/edgeos/device-uuid)
- Default 'edge' user with appropriate permissions and password
- USB gadget service renamed to edgeos-usbgadget for consistent branding
- USB device strings show "EdgeOS" manufacturer and "EdgeOS Device" product
- Device serial dynamically pulled from hardware or UUID

These changes bring the EdgeOS branding from edgeos-flavor repository to the Yocto-based meta-edgeos build system, ensuring consistent identity management across both build systems.

Features are configurable via Yocto variables:
- EDGEOS_HOSTNAME (default: edgeos-device)
- EDGEOS_BUILD_ID (default: git short hash, falls back to "dev")

Implementation details:
- Build ID uses git commit hash for traceable builds
- Edge user created with UID 1000, groups: dialout, video, audio, users
- Edge user has sudo NOPASSWD access for development
- Password set via useradd with SHA-512 hash
- USB gadget changes integrated into base recipe (no bbappend)
- USB device uses actual hardware serial or UUID for identification

Fixes applied during development:
- Removed non-existent groups that caused useradd failures
- Fixed password hash generation for edge user
- Consolidated USB gadget changes into base recipe to avoid bbappend issues
- Added proper escape sequences for password hash in recipe

Testing confirmed:
- Hostname shows as "edgeos-device"
- Edge user can login with password "edge"
- Device UUID generated and persisted across reboots
- Build ID shows in /etc/edgeos-build-id
- USB device appears as "EdgeOS Device" on host systems

Note: MOTD/welcome banner tracked separately in issue #13