### PR TITLE
Add mDNS/Avahi service configuration for network discovery

### DIFF
--- a/meta-edgeos/recipes-connectivity/avahi/files/edgeos-hostname.service
+++ b/meta-edgeos/recipes-connectivity/avahi/files/edgeos-hostname.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=EdgeOS Hostname Setup
+Before=avahi-daemon.service network.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/generate-hostname.sh
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-edgeos/recipes-connectivity/avahi/files/edgeos-mdns.service
+++ b/meta-edgeos/recipes-connectivity/avahi/files/edgeos-mdns.service
@@ -1,0 +1,45 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">EdgeOS on %h</name>
+  
+  <!-- SSH Service -->
+  <service>
+    <type>_ssh._tcp</type>
+    <port>22</port>
+    <txt-record>model=EdgeOS</txt-record>
+    <txt-record>platform=Raspberry Pi</txt-record>
+  </service>
+  
+  <!-- Device Info Service -->
+  <service>
+    <type>_device-info._tcp</type>
+    <port>0</port>
+    <txt-record>model=EdgeOS Device</txt-record>
+    <txt-record>version=1.0</txt-record>
+  </service>
+  
+  <!-- HTTP Service (if running) -->
+  <service>
+    <type>_http._tcp</type>
+    <port>80</port>
+    <txt-record>path=/</txt-record>
+    <txt-record>platform=EdgeOS</txt-record>
+  </service>
+  
+  <!-- HTTPS Service (if running) -->
+  <service>
+    <type>_https._tcp</type>
+    <port>443</port>
+    <txt-record>path=/</txt-record>
+    <txt-record>platform=EdgeOS</txt-record>
+  </service>
+  
+  <!-- EdgeOS Agent Service -->
+  <service>
+    <type>_edge-agent._tcp</type>
+    <port>8080</port>
+    <txt-record>version=1.0</txt-record>
+    <txt-record>api=/api/v1</txt-record>
+  </service>
+</service-group>

--- a/meta-edgeos/recipes-connectivity/avahi/files/generate-hostname.sh
+++ b/meta-edgeos/recipes-connectivity/avahi/files/generate-hostname.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# EdgeOS Hostname Generation Script
+# Generates a unique hostname based on device serial number
+#
+
+set -e
+
+# Logging
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    logger -t edgeos-hostname "$*"
+}
+
+# Get device serial number or unique identifier
+get_device_id() {
+    local device_id=""
+    
+    # Try to get Raspberry Pi serial
+    if [ -f /proc/cpuinfo ]; then
+        device_id=$(grep Serial /proc/cpuinfo 2>/dev/null | cut -d':' -f2 | tr -d ' ' || true)
+    fi
+    
+    # If no serial found, try machine-id
+    if [ -z "${device_id}" ] && [ -f /etc/machine-id ]; then
+        device_id=$(cat /etc/machine-id | head -c 16)
+    fi
+    
+    # If still no ID, generate one
+    if [ -z "${device_id}" ]; then
+        device_id=$(ip link show | grep ether | head -1 | awk '{print $2}' | tr -d ':' | head -c 16)
+    fi
+    
+    # Fallback to random
+    if [ -z "${device_id}" ]; then
+        device_id=$(tr -dc 'a-f0-9' < /dev/urandom | head -c 16)
+    fi
+    
+    echo "${device_id}"
+}
+
+# Generate hostname
+generate_hostname() {
+    local device_id=$(get_device_id)
+    
+    # Take last 8 characters for readability
+    local short_id="${device_id: -8}"
+    
+    # Convert to lowercase
+    short_id=$(echo "${short_id}" | tr '[:upper:]' '[:lower:]')
+    
+    # Create hostname
+    local hostname="edgeos-${short_id}"
+    
+    echo "${hostname}"
+}
+
+# Set hostname
+set_hostname() {
+    local new_hostname="$1"
+    local current_hostname=$(hostname)
+    
+    if [ "${current_hostname}" = "${new_hostname}" ]; then
+        log "Hostname already set to ${new_hostname}"
+        return 0
+    fi
+    
+    log "Setting hostname to ${new_hostname}"
+    
+    # Set hostname using hostnamectl if available
+    if command -v hostnamectl >/dev/null 2>&1; then
+        hostnamectl set-hostname "${new_hostname}"
+    else
+        # Fallback to traditional method
+        echo "${new_hostname}" > /etc/hostname
+        hostname "${new_hostname}"
+    fi
+    
+    # Update /etc/hosts
+    if ! grep -q "${new_hostname}" /etc/hosts; then
+        # Remove old edgeos entries
+        sed -i '/edgeos-/d' /etc/hosts
+        
+        # Add new entry
+        echo "127.0.1.1 ${new_hostname} ${new_hostname}.local" >> /etc/hosts
+    fi
+    
+    log "Hostname set successfully to ${new_hostname}"
+}
+
+# Main execution
+main() {
+    log "Starting EdgeOS hostname generation"
+    
+    # Check if we should skip (for development or custom setups)
+    if [ -f /etc/edgeos-hostname-override ]; then
+        log "Hostname override found, skipping automatic generation"
+        exit 0
+    fi
+    
+    # Generate and set hostname
+    local hostname=$(generate_hostname)
+    set_hostname "${hostname}"
+    
+    # Store the generated hostname for reference
+    echo "${hostname}" > /etc/edgeos-hostname
+    
+    # Restart avahi-daemon if it's running to pick up new hostname
+    if systemctl is-active --quiet avahi-daemon.service; then
+        log "Restarting avahi-daemon to pick up new hostname"
+        systemctl restart avahi-daemon.service
+    fi
+    
+    log "EdgeOS hostname generation completed"
+}
+
+# Run main function
+main "$@"

--- a/meta-edgeos/recipes-connectivity/avahi/files/nsswitch.conf.append
+++ b/meta-edgeos/recipes-connectivity/avahi/files/nsswitch.conf.append
@@ -1,0 +1,4 @@
+# Ensure mDNS resolution is enabled
+# This will be merged with the existing nsswitch.conf
+
+hosts: files mdns_minimal [NOTFOUND=return] dns mdns

--- a/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-base.bb
+++ b/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-base.bb
@@ -19,6 +19,9 @@ RDEPENDS:${PN} = " \
     edgeos-motd \
     edgeos-identity \
     edgeos-user \
+    avahi-daemon \
+    avahi-utils \
+    libnss-mdns \
     "
 
 RDEPENDS:${PN}:append = " \


### PR DESCRIPTION
  Implements automatic mDNS service discovery allowing devices to be accessed
  via hostname.local without knowing IP addresses. Each device gets a unique
  hostname based on hardware serial number or MAC address.

  Key features:
  - Automatic hostname generation (edgeos-XXXXXXXX format)
  - mDNS service advertisement for SSH, HTTP/HTTPS, and edge-agent
  - Integration with systemd for proper service ordering
  - NSS configuration for .local domain resolution
  - Avahi daemon optimized for embedded use

  Components added:
  - avahi_%.bbappend: Configures and extends avahi daemon
  - generate-hostname.sh: Creates unique hostname from device ID
  - edgeos-hostname.service: Sets hostname before network startup
  - edgeos-mdns.service: Advertises available services via mDNS
  - nsswitch.conf.append: Enables mDNS name resolution

  Added packages to base image:
  - avahi-daemon: mDNS/DNS-SD daemon
  - avahi-utils: Command-line tools for debugging
  - libnss-mdns: Name Service Switch module for .local resolution

  The implementation ensures devices are discoverable on the network as
  edgeos-XXXXXXXX.local, compatible with Bonjour (macOS), Avahi (Linux),
  and mDNS (Windows).

  Resolves: #9