### PR TITLE
Add offline-capable edge-agent with auto-update support

### DIFF
--- a/meta-edgeos/recipes-core/edge-agent/edge-agent.bb
+++ b/meta-edgeos/recipes-core/edge-agent/edge-agent.bb
@@ -1,13 +1,12 @@
-SUMMARY = "EdgeOS Agent - Edge device management and control"
-DESCRIPTION = "Downloads and manages the EdgeOS agent binary for device management"
+SUMMARY = "EdgeOS Agent"
+DESCRIPTION = "EdgeOS agent binary for device management"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = "file://download-edge-agent.sh \
-           file://edge-agent-updater.sh \
-           file://edge-agent.service \
+SRC_URI = "file://edge-agent.service \
            file://edge-agent-updater.service \
-           file://edge-agent-updater.timer"
+           file://edge-agent-updater.timer \
+           file://edge-agent-updater.sh"
 
 S = "${WORKDIR}"
 
@@ -16,174 +15,79 @@ inherit systemd
 SYSTEMD_SERVICE:${PN} = "edge-agent.service edge-agent-updater.service edge-agent-updater.timer"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
-# Architecture mapping
-def get_edge_agent_arch(d):
-    target_arch = d.getVar('TARGET_ARCH')
-    if target_arch == 'aarch64':
-        return 'arm64'
-    elif target_arch == 'x86_64':
-        return 'amd64'
-    elif target_arch.startswith('arm'):
-        return 'arm'
-    else:
-        return target_arch
-
-EDGE_AGENT_ARCH = "${@get_edge_agent_arch(d)}"
-EDGE_AGENT_VERSION ?= "latest"
-EDGE_AGENT_GITHUB_REPO = "edgeengineer/edge-agent"
-
-# Try to download at build time if network is available
 do_compile() {
-    # Create a temporary download script for build-time use
-    cat > ${B}/build-download.sh << 'EOF'
-#!/bin/bash
-set -e
+    bbnote "Downloading edge-agent binary for aarch64..."
 
-GITHUB_REPO="${1}"
-VERSION="${2}"
-ARCH="${3}"
-OUTPUT_FILE="${4}"
+    # Get the latest pre-release from GitHub
+    RELEASES_URL="https://api.github.com/repos/edgeengineer/edge-agent/releases"
 
-echo "Attempting to download edge-agent at build time..."
-echo "Repository: ${GITHUB_REPO}"
-echo "Version: ${VERSION}"
-echo "Architecture: ${ARCH}"
+    # Fetch releases list
+    wget -q -O ${B}/releases.json "${RELEASES_URL}" || \
+        curl -sL -o ${B}/releases.json "${RELEASES_URL}" || \
+        bbfatal "Failed to fetch releases from GitHub"
 
-# Determine the latest release if version is "latest"
-if [ "${VERSION}" = "latest" ]; then
-    API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
-else
-    API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${VERSION}"
-fi
+    # Extract download URL for aarch64 binary using simple grep (no jq dependency)
+    DOWNLOAD_URL=$(cat ${B}/releases.json | \
+        grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*edge-agent-linux-static-musl-aarch64[^"]*"' | \
+        head -1 | cut -d'"' -f4)
 
-# Try to get release information
-if command -v curl >/dev/null 2>&1; then
-    RELEASE_INFO=$(curl -sL "${API_URL}" 2>/dev/null || echo "")
-elif command -v wget >/dev/null 2>&1; then
-    RELEASE_INFO=$(wget -qO- "${API_URL}" 2>/dev/null || echo "")
-else
-    echo "Neither curl nor wget available, skipping build-time download"
-    exit 1
-fi
-
-if [ -z "${RELEASE_INFO}" ] || echo "${RELEASE_INFO}" | grep -q "Not Found"; then
-    echo "Could not fetch release information, will download at runtime"
-    exit 1
-fi
-
-# Parse download URL for the architecture
-DOWNLOAD_URL=$(echo "${RELEASE_INFO}" | grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*edge-agent-linux-'${ARCH}'[^"]*"' | cut -d'"' -f4 | head -1)
-
-if [ -z "${DOWNLOAD_URL}" ]; then
-    # Try alternative naming patterns
-    DOWNLOAD_URL=$(echo "${RELEASE_INFO}" | grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*edge-agent[^"]*linux[^"]*'${ARCH}'[^"]*"' | cut -d'"' -f4 | head -1)
-fi
-
-if [ -z "${DOWNLOAD_URL}" ]; then
-    echo "No suitable binary found for architecture: ${ARCH}"
-    exit 1
-fi
-
-echo "Downloading from: ${DOWNLOAD_URL}"
-
-# Download the file
-if command -v curl >/dev/null 2>&1; then
-    curl -L -o "${OUTPUT_FILE}.tmp" "${DOWNLOAD_URL}" || exit 1
-else
-    wget -O "${OUTPUT_FILE}.tmp" "${DOWNLOAD_URL}" || exit 1
-fi
-
-# Handle different file types
-if echo "${DOWNLOAD_URL}" | grep -q '\.tar\.gz$'; then
-    tar -xzf "${OUTPUT_FILE}.tmp" -O > "${OUTPUT_FILE}" 2>/dev/null || \
-    tar -xzf "${OUTPUT_FILE}.tmp" edge-agent > "${OUTPUT_FILE}" 2>/dev/null || \
-    tar -xzf "${OUTPUT_FILE}.tmp" --wildcards '*/edge-agent' --to-stdout > "${OUTPUT_FILE}" 2>/dev/null
-    rm -f "${OUTPUT_FILE}.tmp"
-elif echo "${DOWNLOAD_URL}" | grep -q '\.zip$'; then
-    unzip -p "${OUTPUT_FILE}.tmp" edge-agent > "${OUTPUT_FILE}" 2>/dev/null || \
-    unzip -p "${OUTPUT_FILE}.tmp" '*/edge-agent' > "${OUTPUT_FILE}" 2>/dev/null
-    rm -f "${OUTPUT_FILE}.tmp"
-else
-    # Assume it's a binary
-    mv "${OUTPUT_FILE}.tmp" "${OUTPUT_FILE}"
-fi
-
-if [ -f "${OUTPUT_FILE}" ] && [ -s "${OUTPUT_FILE}" ]; then
-    chmod +x "${OUTPUT_FILE}"
-    echo "Successfully downloaded edge-agent binary"
-    exit 0
-else
-    echo "Download completed but binary not found or empty"
-    exit 1
-fi
-EOF
-    chmod +x ${B}/build-download.sh
-    
-    # Try to download at build time, but don't fail if it doesn't work
-    if ${B}/build-download.sh "${EDGE_AGENT_GITHUB_REPO}" "${EDGE_AGENT_VERSION}" "${EDGE_AGENT_ARCH}" "${B}/edge-agent"; then
-        echo "Edge-agent downloaded successfully at build time"
-    else
-        echo "Build-time download failed, will download at runtime"
+    if [ -z "${DOWNLOAD_URL}" ]; then
+        bbfatal "Failed to find edge-agent-linux-static-musl-aarch64 binary in releases"
     fi
+
+    bbnote "Downloading from: ${DOWNLOAD_URL}"
+
+    # Download the binary archive
+    wget -O ${B}/edge-agent.tar.gz "${DOWNLOAD_URL}" || \
+        curl -L -o ${B}/edge-agent.tar.gz "${DOWNLOAD_URL}" || \
+        bbfatal "Failed to download edge-agent binary"
+
+    # Extract the archive
+    tar -xzf ${B}/edge-agent.tar.gz -C ${B}
+
+    # Find and prepare the binary
+    if [ ! -f ${B}/edge-agent ]; then
+        BINARY=$(find ${B} -name edge-agent -type f ! -path "*/edge-cli*" | head -1)
+        if [ -n "${BINARY}" ]; then
+            mv "${BINARY}" ${B}/edge-agent
+        else
+            bbfatal "edge-agent binary not found in archive"
+        fi
+    fi
+
+    chmod +x ${B}/edge-agent
+    bbnote "edge-agent binary ready"
 }
 
 do_install() {
-    # Create necessary directories
+    # Install the pre-downloaded binary
     install -d ${D}/usr/local/bin
-    install -d ${D}/opt/edgeos/bin
-    install -d ${D}${systemd_system_unitdir}
-    install -d ${D}/var/lib/edge-agent
-    
-    # Install the download script
-    install -m 0755 ${WORKDIR}/download-edge-agent.sh ${D}/opt/edgeos/bin/
-    
-    # Install the updater script
-    install -m 0755 ${WORKDIR}/edge-agent-updater.sh ${D}/opt/edgeos/bin/
-    
-    # If we downloaded the binary at build time, install it
-    if [ -f ${B}/edge-agent ]; then
-        install -m 0755 ${B}/edge-agent ${D}/usr/local/bin/edge-agent
-        # Create a backup copy
-        install -m 0755 ${B}/edge-agent ${D}/opt/edgeos/bin/edge-agent.backup
-    else
-        # Create a placeholder script that will download on first run
-        cat > ${D}/usr/local/bin/edge-agent << 'EOF'
-#!/bin/sh
-echo "Edge-agent not yet installed, downloading..."
-/opt/edgeos/bin/download-edge-agent.sh
-if [ -f /usr/local/bin/edge-agent.real ]; then
-    mv /usr/local/bin/edge-agent.real /usr/local/bin/edge-agent
-    exec /usr/local/bin/edge-agent "$@"
-else
-    echo "Failed to download edge-agent"
-    exit 1
-fi
-EOF
-        chmod +x ${D}/usr/local/bin/edge-agent
-    fi
-    
+    install -m 0755 ${B}/edge-agent ${D}/usr/local/bin/edge-agent
+
     # Install systemd services
+    install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/edge-agent.service ${D}${systemd_system_unitdir}/
     install -m 0644 ${WORKDIR}/edge-agent-updater.service ${D}${systemd_system_unitdir}/
     install -m 0644 ${WORKDIR}/edge-agent-updater.timer ${D}${systemd_system_unitdir}/
-    
-    # Pass configuration via environment file
-    install -d ${D}${sysconfdir}/default
-    cat > ${D}${sysconfdir}/default/edge-agent << EOF
-# Edge Agent Configuration
-EDGE_AGENT_GITHUB_REPO="${EDGE_AGENT_GITHUB_REPO}"
-EDGE_AGENT_VERSION="${EDGE_AGENT_VERSION}"
-EDGE_AGENT_ARCH="${EDGE_AGENT_ARCH}"
-EOF
+
+    # Install updater script
+    install -d ${D}/opt/edgeos/bin
+    install -m 0755 ${WORKDIR}/edge-agent-updater.sh ${D}/opt/edgeos/bin/
+
+    # Create runtime directory
+    install -d ${D}/var/lib/edge-agent
 }
 
 FILES:${PN} = "/usr/local/bin/* \
                /opt/edgeos/bin/* \
                ${systemd_system_unitdir}/* \
-               ${sysconfdir}/default/edge-agent \
                /var/lib/edge-agent"
 
-RDEPENDS:${PN} = "bash curl tar gzip jq"
-
-# Allow network access during build (optional, for build-time download)
+# Allow network access during build
 do_compile[network] = "1"
+
+# Skip QA checks for pre-built binary
+INSANE_SKIP:${PN} += "already-stripped"
+
+# Runtime dependencies
+RDEPENDS:${PN} = "bash"

--- a/meta-edgeos/recipes-core/edge-agent/files/edge-agent.service
+++ b/meta-edgeos/recipes-core/edge-agent/files/edge-agent.service
@@ -6,26 +6,26 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sh -c 'if [ ! -f /usr/local/bin/edge-agent ] || grep -q "Edge-agent not yet installed" /usr/local/bin/edge-agent 2>/dev/null; then /opt/edgeos/bin/download-edge-agent.sh; fi'
-ExecStart=/usr/local/bin/edge-agent daemon
+ExecStart=/usr/local/bin/edge-agent
 Restart=always
 RestartSec=10
+
+# Logging
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=edge-agent
 
-# Security settings
-NoNewPrivileges=true
-PrivateTmp=true
-ProtectHome=true
-ProtectSystem=strict
-ReadWritePaths=/var/lib/edge-agent /var/log
-
 # Resource limits
 LimitNOFILE=65536
 LimitNPROC=4096
+MemoryMax=2G
+CPUQuota=200%
 
-# Environment
+# Container management support
+Delegate=yes
+KillMode=process
+
+# Environment file for configuration (optional)
 EnvironmentFile=-/etc/default/edge-agent
 
 [Install]

--- a/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-base.bb
+++ b/meta-edgeos/recipes-core/packagegroups/packagegroup-edgeos-base.bb
@@ -16,6 +16,9 @@ RDEPENDS:${PN} = " \
     zstd \
     iproute2 \
     vim \
+    ncurses \
+    ncurses-terminfo \
+    ncurses-terminfo-base \
     edgeos-motd \
     edgeos-identity \
     edgeos-user \


### PR DESCRIPTION
  - Download edge-agent at build time for offline deployment
  - Add systemd auto-updater service and timer
  - Fix service configuration to match edgeos-flavor pattern
  - Add ncurses for terminal support
  - Fix log pollution in download scripts