### PR TITLE
Add mDNS service broadcasting with dynamic device UUID

### DIFF
--- a/meta-edgeos/recipes-connectivity/avahi/files/edgeos-mdns.service
+++ b/meta-edgeos/recipes-connectivity/avahi/files/edgeos-mdns.service
@@ -42,4 +42,11 @@
     <txt-record>version=1.0</txt-record>
     <txt-record>api=/api/v1</txt-record>
   </service>
+
+  <!-- EdgeOS Device Service -->
+  <service>
+    <type>_edgeos._udp</type>
+    <port>50051</port>
+    <txt-record>edgeosdevice=SOME_DEVICE_ID</txt-record>
+  </service>
 </service-group>

--- a/meta-edgeos/recipes-core/edgeos-identity/edgeos-identity_1.0.bb
+++ b/meta-edgeos/recipes-core/edgeos-identity/edgeos-identity_1.0.bb
@@ -7,6 +7,7 @@ inherit systemd
 
 SRC_URI = " \
     file://generate-uuid.sh \
+    file://update-mdns-uuid.sh \
     file://edgeos-identity.service \
     "
 
@@ -16,9 +17,10 @@ SYSTEMD_SERVICE:${PN} = "edgeos-identity.service"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 do_install() {
-    # Install UUID generation script
+    # Install UUID generation scripts
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/generate-uuid.sh ${D}${bindir}/
+    install -m 0755 ${WORKDIR}/update-mdns-uuid.sh ${D}${bindir}/
 
     # Install systemd service
     install -d ${D}${systemd_system_unitdir}
@@ -29,7 +31,8 @@ do_install() {
 }
 
 FILES:${PN} += "${bindir}/generate-uuid.sh"
+FILES:${PN} += "${bindir}/update-mdns-uuid.sh"
 FILES:${PN} += "${systemd_system_unitdir}/edgeos-identity.service"
 FILES:${PN} += "${sysconfdir}/edgeos"
 
-RDEPENDS:${PN} = "bash util-linux-uuidgen"
+RDEPENDS:${PN} = "bash util-linux-uuidgen avahi-daemon"

--- a/meta-edgeos/recipes-core/edgeos-identity/files/edgeos-identity.service
+++ b/meta-edgeos/recipes-core/edgeos-identity/files/edgeos-identity.service
@@ -1,13 +1,13 @@
 [Unit]
-Description=EdgeOS Device Identity Setup
+Description=EdgeOS Device Identity and mDNS Setup
 DefaultDependencies=no
-Before=sysinit.target
+Before=avahi-daemon.service
 After=local-fs.target
-ConditionPathExists=!/etc/edgeos/device-uuid
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/generate-uuid.sh
+ExecStart=/usr/bin/update-mdns-uuid.sh
 RemainAfterExit=yes
 StandardOutput=journal
 StandardError=journal

--- a/meta-edgeos/recipes-core/edgeos-identity/files/update-mdns-uuid.sh
+++ b/meta-edgeos/recipes-core/edgeos-identity/files/update-mdns-uuid.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# EdgeOS mDNS UUID Update Script
+# Updates the Avahi service file with the device UUID
+
+UUID_FILE="/etc/edgeos/device-uuid"
+SERVICE_FILE="/etc/avahi/services/edgeos-mdns.service"
+
+# Wait for UUID file to exist (in case of race condition)
+for i in {1..10}; do
+    if [ -f "$UUID_FILE" ]; then
+        break
+    fi
+    sleep 1
+done
+
+if [ ! -f "$UUID_FILE" ]; then
+    echo "Error: UUID file not found at $UUID_FILE"
+    exit 1
+fi
+
+if [ ! -f "$SERVICE_FILE" ]; then
+    echo "Error: Avahi service file not found at $SERVICE_FILE"
+    exit 1
+fi
+
+# Read the UUID
+UUID=$(cat "$UUID_FILE")
+
+# Replace SOME_DEVICE_ID with actual UUID
+sed -i "s/SOME_DEVICE_ID/$UUID/g" "$SERVICE_FILE"
+
+echo "Updated mDNS service with device UUID: $UUID"
+logger -t edgeos-identity "Updated mDNS service with UUID: $UUID"
+
+# Reload Avahi to pick up changes if it's running
+if systemctl is-active --quiet avahi-daemon; then
+    avahi-daemon --reload || true
+fi
+
+exit 0


### PR DESCRIPTION
  - Add _edgeos._udp service broadcasting on port 50051 with device UUID TXT record
  - Enable D-Bus support in Avahi for proper service publishing
  - Implement UUID injection into mDNS service at boot via update-mdns-uuid.sh
  - Integrate UUID generation with mDNS configuration in edgeos-identity service
  - Ensure edgeos-identity runs before avahi-daemon to update service files

  This enables EdgeOS devices to broadcast their unique UUID via mDNS for
  network discovery and identification.