### PR TITLE
Add dynamic MAC address generation for USB gadget

### DIFF
--- a/meta-edgeos/recipes-core/edgeos-utils/edgeos-utils.bb
+++ b/meta-edgeos/recipes-core/edgeos-utils/edgeos-utils.bb
@@ -1,0 +1,19 @@
+SUMMARY = "EdgeOS utility scripts"
+DESCRIPTION = "Common utility scripts for EdgeOS including MAC address generation"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://edgeos-generate-mac"
+
+S = "${WORKDIR}"
+
+do_install() {
+    # Install MAC generation utility
+    install -d ${D}${libexecdir}
+    install -m 0755 ${WORKDIR}/edgeos-generate-mac ${D}${libexecdir}/edgeos-generate-mac
+}
+
+FILES:${PN} = "${libexecdir}/edgeos-generate-mac"
+
+# Runtime dependencies
+RDEPENDS:${PN} = "coreutils"

--- a/meta-edgeos/recipes-core/edgeos-utils/files/edgeos-generate-mac
+++ b/meta-edgeos/recipes-core/edgeos-utils/files/edgeos-generate-mac
@@ -1,0 +1,91 @@
+#!/bin/sh
+# EdgeOS MAC Address Generator
+# Generates deterministic, locally-administered MAC addresses based on device serial
+#
+# Usage: edgeos-generate-mac <interface-name>
+# Example: edgeos-generate-mac usb-dev
+#          edgeos-generate-mac usb-host
+
+set -eu
+
+# Function to generate a MAC address from a string
+generate_mac() {
+    local input="$1"
+
+    # Generate SHA-256 hash of the input
+    local hash=$(echo -n "$input" | sha256sum | awk '{print $1}')
+
+    # Take first 12 characters of the hash
+    local mac_base=${hash:0:12}
+
+    # Ensure locally administered address (set bit 1 of first octet)
+    # This means the second bit should be 1 (x2, x6, xA, xE)
+    local first_byte=${mac_base:0:2}
+    local second_char=$(printf '%x' $((0x$first_byte & 0xfe | 0x02)))
+
+    # Format as MAC address
+    printf "%02x:%02x:%02x:%02x:%02x:%02x\n" \
+       0x$second_char \
+       0x${mac_base:2:2} \
+       0x${mac_base:4:2} \
+       0x${mac_base:6:2} \
+       0x${mac_base:8:2} \
+       0x${mac_base:10:2}
+}
+
+# Get device serial number with fallback chain
+get_device_serial() {
+    local serial=""
+
+    # Try device tree serial (Raspberry Pi, some ARM devices)
+    if [ -f /proc/device-tree/serial-number ]; then
+        serial=$(cat /proc/device-tree/serial-number 2>/dev/null | tr -d '\0')
+        [ -n "$serial" ] && echo "$serial" && return 0
+    fi
+
+    # Try EdgeOS device UUID
+    if [ -f /etc/edgeos/device-uuid ]; then
+        serial=$(cat /etc/edgeos/device-uuid 2>/dev/null)
+        [ -n "$serial" ] && echo "$serial" && return 0
+    fi
+
+    # Try CPU serial from /proc/cpuinfo (older Raspberry Pi)
+    if [ -f /proc/cpuinfo ]; then
+        serial=$(awk -F': ' '/Serial/ {print $2}' /proc/cpuinfo 2>/dev/null | tr -d ' ')
+        [ -n "$serial" ] && echo "$serial" && return 0
+    fi
+
+    # Try primary network interface MAC as fallback
+    if [ -f /sys/class/net/eth0/address ]; then
+        serial=$(cat /sys/class/net/eth0/address 2>/dev/null)
+        [ -n "$serial" ] && echo "$serial" && return 0
+    fi
+
+    # Last resort: use machine ID
+    if [ -f /etc/machine-id ]; then
+        serial=$(cat /etc/machine-id 2>/dev/null)
+        [ -n "$serial" ] && echo "$serial" && return 0
+    fi
+
+    # Ultimate fallback: timestamp
+    echo "$(hostname)-$(date +%s)"
+}
+
+# Main logic
+main() {
+    if [ $# -ne 1 ]; then
+        echo "Usage: $0 <interface-suffix>" >&2
+        echo "Examples:" >&2
+        echo "  $0 usb-dev    # Generate MAC for device side" >&2
+        echo "  $0 usb-host   # Generate MAC for host side" >&2
+        exit 1
+    fi
+
+    local interface="$1"
+    local serial=$(get_device_serial)
+
+    # Generate unique, deterministic MAC for this interface
+    generate_mac "${serial}-${interface}"
+}
+
+main "$@"

--- a/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget.sh
+++ b/meta-edgeos/recipes-core/usb-gadget/files/usb-gadget.sh
@@ -78,9 +78,21 @@ prepare() {
 
     # --- NCM function ---
     mkdir -p "$G/functions/$FUNC_NCM"
-    # Locally administered MACs (02:…)
-    echo "02:12:34:56:78:ca" > "$G/functions/$FUNC_NCM/dev_addr"
-    echo "02:12:34:56:78:cb" > "$G/functions/$FUNC_NCM/host_addr"
+
+    # Generate dynamic MAC addresses based on device serial
+    if [ -x /usr/libexec/edgeos-generate-mac ]; then
+        DEV_MAC=$(/usr/libexec/edgeos-generate-mac usb-dev)
+        HOST_MAC=$(/usr/libexec/edgeos-generate-mac usb-host)
+        log "Using generated MACs: dev=$DEV_MAC host=$HOST_MAC"
+    else
+        # Fallback to static MACs if generator not available
+        DEV_MAC="02:12:34:56:78:ca"
+        HOST_MAC="02:12:34:56:78:cb"
+        log "Warning: MAC generator not found, using static MACs"
+    fi
+
+    echo "$DEV_MAC" > "$G/functions/$FUNC_NCM/dev_addr"
+    echo "$HOST_MAC" > "$G/functions/$FUNC_NCM/host_addr"
     # Optional tuning:
     # echo 5 > "$G/functions/$FUNC_NCM/qmult"
 

--- a/meta-edgeos/recipes-core/usb-gadget/usb-gadget.bb
+++ b/meta-edgeos/recipes-core/usb-gadget/usb-gadget.bb
@@ -62,7 +62,7 @@ do_install() {
 SYSTEMD_SERVICE:${PN} = "edgeos-usbgadget-prepare.service"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
-RDEPENDS:${PN} += "udev kmod iproute2 systemd-networkd"
+RDEPENDS:${PN} += "udev kmod iproute2 systemd-networkd edgeos-utils"
 
 FILES:${PN} += "\
     ${sbindir}/edgeos-usbgadget.sh \


### PR DESCRIPTION
  - Create edgeos-utils package with MAC generation utility
  - Generate unique, deterministic MACs based on device serial
  - Update USB gadget to use dynamically generated MACs
  - Ensures each device gets unique but consistent MAC addresses