### PR TITLE
Configure IPv6 for USB network interface (EDG-291)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -57,6 +57,8 @@ BBLAYERS ?= " \
   ${TOPDIR}/../sources/poky/meta \
   ${TOPDIR}/../sources/poky/meta-poky \
   ${TOPDIR}/../sources/meta-openembedded/meta-oe \
+  ${TOPDIR}/../sources/meta-openembedded/meta-python \
+  ${TOPDIR}/../sources/meta-openembedded/meta-networking \
   ${TOPDIR}/../sources/meta-raspberrypi \
   ${TOPDIR}/../meta-edgeos \
   "

--- a/docs/USB_NETWORKING.md
+++ b/docs/USB_NETWORKING.md
@@ -1,0 +1,222 @@
+# USB Networking Features
+
+This document describes the USB networking improvements added to EdgeOS for reliable host-device communication over USB.
+
+## Overview
+
+EdgeOS devices connect to host computers via USB using the NCM (Network Control Model) protocol, creating a virtual Ethernet interface. Recent improvements ensure reliable IPv6 connectivity and prevent MAC address conflicts between multiple devices.
+
+## Features
+
+### 1. Dynamic MAC Address Generation (EDG-290)
+
+**Problem**: Previously used hardcoded MAC addresses caused conflicts when multiple EdgeOS devices were connected to the same host.
+
+**Solution**: MAC addresses are now dynamically generated based on the device's unique serial number.
+
+#### Implementation
+- Location: `/usr/libexec/edgeos-generate-mac`
+- Method: SHA256 hash of device serial + interface name, with locally administered bit set
+- Result: Deterministic, unique MAC addresses per device
+
+#### Generated MACs
+- Device MAC: `ee:b5:ad:79:79:c5` (example, varies by device serial)
+- Host MAC: `ea:b5:ad:79:79:c6` (example, varies by device serial)
+
+### 2. IPv6 Router Advertisement (EDG-291)
+
+**Problem**: Host computers couldn't establish IPv6 connectivity with EdgeOS devices over USB.
+
+**Solution**: Implemented Router Advertisement Daemon (radvd) to enable automatic IPv6 configuration.
+
+#### Configuration
+- Service: `radvd.service`
+- Config: `/etc/radvd.conf`
+- Interface: `usb0`
+
+#### Features
+- Sends Router Advertisements every 3-10 seconds
+- Enables IPv6 link-local addresses (fe80::/64)
+- Compatible with macOS Internet Connection Sharing
+- Uses SLAAC (Stateless Address Autoconfiguration)
+
+#### Host IPv6 Address
+After connection, the host will have an IPv6 address like:
+```
+fe80::1076:5096:132b:b89%en36
+```
+
+#### Device IPv6 Address
+The device's IPv6 address is derived from its MAC:
+```
+fe80::ecb5:adff:fe79:79c5
+```
+
+### 3. mDNS Service Broadcasting (EDG-216)
+
+**Problem**: Devices needed to be discoverable on the network with their capabilities advertised.
+
+**Solution**: Avahi service configuration with dynamic device UUID.
+
+#### Implementation
+- Service: `avahi-daemon`
+- Config: `/etc/avahi/services/edgeos.service`
+- Hostname: `edgeos-device.local`
+- UUID: Dynamically generated from device serial
+
+## Network Configuration
+
+### USB Interface (`usb0`)
+
+The device's USB network interface is configured via systemd-networkd:
+
+```ini
+[Network]
+Address=192.168.7.1/24
+DHCPServer=yes
+LinkLocalAddressing=yes
+IPv6LinkLocalAddressGenerationMode=eui64
+```
+
+### Services Running
+- **DHCP Server**: Provides IPv4 addresses (192.168.7.x) to connected hosts
+- **Router Advertisement**: Enables IPv6 link-local connectivity
+- **mDNS/Avahi**: Makes device discoverable as `edgeos-device.local`
+
+## Usage
+
+### Connecting to the Device
+
+1. **Via mDNS** (recommended):
+   ```bash
+   ssh root@edgeos-device.local
+   ping6 edgeos-device.local
+   ```
+
+2. **Via IPv6 link-local**:
+   ```bash
+   # Find interface name (e.g., en36 on macOS)
+   ifconfig | grep -B 2 "status: active"
+
+   # Ping device
+   ping6 fe80::ecb5:adff:fe79:79c5%en36
+   ```
+
+3. **Via IPv4** (when DHCP is working):
+   ```bash
+   ssh root@192.168.7.1
+   ```
+
+### Verifying IPv6 Connectivity
+
+After connecting the device:
+
+```bash
+# Check if host has IPv6 address
+ifconfig en36 | grep inet6
+
+# If no IPv6, restart the network service (macOS)
+networksetup -setnetworkserviceenabled "EdgeOS Device" off
+sleep 2
+networksetup -setnetworkserviceenabled "EdgeOS Device" on
+
+# Test connectivity
+ping6 -c 2 fe80::ecb5:adff:fe79:79c5%en36
+```
+
+### Troubleshooting
+
+#### No IPv6 Address on Host
+
+If the host doesn't get an IPv6 address automatically:
+
+1. Check radvd is running on device:
+   ```bash
+   ssh root@edgeos-device.local systemctl status radvd
+   ```
+
+2. Restart network interface on host (see above)
+
+3. Wait 10 seconds for Router Advertisement
+
+#### DHCP Conflict with Internet Connection Sharing
+
+**Issue**: When macOS Internet Connection Sharing is enabled, both the Mac and EdgeOS device try to run DHCP servers, causing conflicts.
+
+**Workaround**: Disable ICS when connecting to EdgeOS devices, or rely on IPv6 connectivity only.
+
+**Tracking**: EDG-295
+
+#### Finding the Device's IPv6 Address
+
+The device's IPv6 link-local address is predictable based on its MAC address:
+- If device MAC is `ee:b5:ad:79:79:c5`
+- IPv6 will be `fe80::ecb5:adff:fe79:79c5`
+
+The MAC address follows EUI-64 format with bit 7 flipped.
+
+## Build Configuration
+
+### Required Yocto Layers
+
+The following layers must be included in `bblayers.conf`:
+```
+meta-openembedded/meta-oe
+meta-openembedded/meta-python
+meta-openembedded/meta-networking
+```
+
+### Build Flags
+
+Enable USB gadget support in `local.conf`:
+```
+EDGEOS_USB_GADGET = "1"
+```
+
+This enables:
+- USB NCM gadget driver
+- systemd-networkd configuration
+- radvd for IPv6
+- DHCP server
+
+## Technical Details
+
+### MAC Address Generation Algorithm
+
+```bash
+generate_mac() {
+    local input="$1"
+    local hash=$(echo -n "$input" | sha256sum | awk '{print $1}')
+    local mac_base=${hash:0:12}
+    # Set locally administered bit (bit 1 of first octet)
+    local first_byte=${mac_base:0:2}
+    local second_char=$(printf '%x' $((0x$first_byte & 0xfe | 0x02)))
+    printf "%02x:%02x:%02x:%02x:%02x:%02x\n" \
+       0x$second_char \
+       0x${mac_base:2:2} \
+       0x${mac_base:4:2} \
+       0x${mac_base:6:2} \
+       0x${mac_base:8:2} \
+       0x${mac_base:10:2}
+}
+```
+
+### Router Advertisement Configuration
+
+Key radvd settings for USB interface:
+- **MinRtrAdvInterval**: 3 seconds (aggressive for quick discovery)
+- **MaxRtrAdvInterval**: 10 seconds
+- **AdvDefaultLifetime**: 0 (not a default router)
+- **Prefix**: fe80::/64 (link-local only)
+
+## Related Linear Issues
+
+- **EDG-290**: Implement dynamic MAC address generation for USB gadget
+- **EDG-291**: Configure IPv6 for USB network interface
+- **EDG-216**: Add mDNS/Avahi service configuration
+- **EDG-295**: DHCP server conflict with macOS ICS
+- **EDG-292**: Implement USB gadget connection detection
+- **EDG-293**: Add USB network auto-recovery mechanism
+- **EDG-294**: Create comprehensive USB troubleshooting guide
+
+All issues are tracked under the "Host-Device USB Communication" project in Linear.

--- a/meta-edgeos/recipes-connectivity/radvd/files/radvd.conf
+++ b/meta-edgeos/recipes-connectivity/radvd/files/radvd.conf
@@ -1,0 +1,29 @@
+# EdgeOS USB Network Router Advertisement Configuration
+# This config enables IPv6 on the USB NCM interface
+
+interface usb0 {
+    # Send Router Advertisements
+    AdvSendAdvert on;
+
+    # Send RAs frequently for quick host configuration
+    MinRtrAdvInterval 3;
+    MaxRtrAdvInterval 10;
+
+    # Low preference so macOS ICS can override if needed
+    AdvDefaultPreference low;
+
+    # Don't advertise as default router (we're just enabling IPv6)
+    AdvDefaultLifetime 0;
+
+    # Use SLAAC, not DHCPv6
+    AdvManagedFlag off;
+    AdvOtherConfigFlag off;
+
+    # Advertise the link-local prefix
+    # This ensures hosts configure their own link-local addresses
+    prefix fe80::/64 {
+        AdvOnLink on;
+        AdvAutonomous on;
+        AdvRouterAddr on;
+    };
+};

--- a/meta-edgeos/recipes-connectivity/radvd/radvd_%.bbappend
+++ b/meta-edgeos/recipes-connectivity/radvd/radvd_%.bbappend
@@ -1,0 +1,39 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://radvd.conf"
+
+inherit systemd
+
+do_install:append() {
+    # Install our custom radvd configuration
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/radvd.conf ${D}${sysconfdir}/radvd.conf
+
+    # Create systemd service if not provided by the recipe
+    if [ ! -f ${D}${systemd_unitdir}/system/radvd.service ]; then
+        install -d ${D}${systemd_unitdir}/system
+        cat > ${D}${systemd_unitdir}/system/radvd.service <<EOF
+[Unit]
+Description=IPv6 Router Advertisement Daemon
+After=network-online.target edgeos-usbgadget-prepare.service
+Wants=network-online.target
+Requires=edgeos-usbgadget-prepare.service
+
+[Service]
+Type=forking
+ExecStartPre=/bin/sh -c 'test -e /sys/class/net/usb0 || sleep 2'
+ExecStart=/usr/sbin/radvd -C /etc/radvd.conf
+ExecReload=/bin/kill -HUP \$MAINPID
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    fi
+}
+
+SYSTEMD_SERVICE:${PN} = "radvd.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+# Runtime dependencies
+RDEPENDS:${PN} += "kernel-module-ipv6"

--- a/meta-edgeos/recipes-core/images/edgeos-image.bb
+++ b/meta-edgeos/recipes-core/images/edgeos-image.bb
@@ -20,7 +20,7 @@ IMAGE_INSTALL += " \
 
 # enable USB peripheral (gadget) support
 ENABLE_DWC2_PERIPHERAL = "${@oe.utils.ifelse(d.getVar('EDGEOS_USB_GADGET') == '1', '1', '0')}"
-IMAGE_INSTALL += " ${@oe.utils.ifelse(d.getVar('EDGEOS_USB_GADGET') == '1', ' usb-gadget', '')}"
+IMAGE_INSTALL += " ${@oe.utils.ifelse(d.getVar('EDGEOS_USB_GADGET') == '1', ' usb-gadget radvd', '')}"
 
 EXTRA_IMAGEDEPENDS += "rpi-cmdline"
 do_image_wic[depends] += "rpi-cmdline:do_deploy wic-tools:do_populate_sysroot e2fsprogs-native:do_populate_sysroot"

--- a/meta-edgeos/recipes-core/usb-gadget/files/10-usb0.network
+++ b/meta-edgeos/recipes-core/usb-gadget/files/10-usb0.network
@@ -7,6 +7,12 @@ Name=usb0
 Address=192.168.7.1/24
 DHCPServer=yes
 ConfigureWithoutCarrier=yes
+# Enable IPv6 link-local addressing
+LinkLocalAddressing=yes
+IPv6LinkLocalAddressGenerationMode=eui64
+IPv6DuplicateAddressDetection=both
+IPv6AcceptRA=yes
+IPv6SendRA=yes
 
 [DHCPServer]
 PoolOffset=2
@@ -15,3 +21,13 @@ PoolSize=1
 # EmitRouter=yes
 # DNS=192.168.7.1
 # EmitDNS=yes
+
+[IPv6SendRA]
+# Low priority to allow macOS ICS to take precedence
+RouterPreference=low
+# Short lifetime for quick adaptation to network changes
+RouterLifetimeSec=30
+# Don't advertise as gateway or DNS
+EmitDNS=no
+Managed=no
+OtherInformation=no


### PR DESCRIPTION
- Enable IPv6 link-local addressing with EUI-64 generation
- Add IPv6 Router Advertisement with low priority
- Configure duplicate address detection for multi-router scenarios
- Accept RAs to work with macOS Internet Connection Sharing
- Use short RA lifetime (30s) for quick network adaptation

This configuration works with or without macOS ICS:
- Without ICS: EdgeOS sends low-priority RAs for basic IPv6
- With ICS: macOS RAs take precedence, both maintain link-local
- Link-local addresses always available for edge-agent connectivity

Note: in testing I saw some instability with ICS that seemed due to the IPv4 setup. IPv4 is beyond the scope of this PR