### PR TITLE
add edgeos-hostname service using device UUID for mDNS

### DIFF
--- a/meta-edgeos/recipes-connectivity/avahi/files/90-edgeos.preset
+++ b/meta-edgeos/recipes-connectivity/avahi/files/90-edgeos.preset
@@ -1,0 +1,1 @@
+enable edgeos-hostname.service

--- a/meta-edgeos/recipes-connectivity/avahi/files/edgeos-hostname.service
+++ b/meta-edgeos/recipes-connectivity/avahi/files/edgeos-hostname.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=EdgeOS Hostname Setup
+Wants=edgeos-identity.service
+After=edgeos-identity.service local-fs.target
 Before=avahi-daemon.service network.target
-After=local-fs.target
 
 [Service]
 Type=oneshot

--- a/meta-edgeos/recipes-connectivity/avahi/files/generate-hostname.sh
+++ b/meta-edgeos/recipes-connectivity/avahi/files/generate-hostname.sh
@@ -1,118 +1,136 @@
 #!/bin/bash
 #
 # EdgeOS Hostname Generation Script
-# Generates a unique hostname based on device serial number
+# Generates a unique hostname based on device UUID (fallback to serial/MAC)
 #
 
-set -e
+set -Eeuo pipefail
+
+UUID_FILE="/etc/edgeos/device-uuid"
+PREFIX="edgeos"
+STATE_DIR="/etc/edgeos"
+STATE_HOSTNAME_FILE="${STATE_DIR}/hostname"
 
 # Logging
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
-    logger -t edgeos-hostname "$*"
+    logger -t edgeos-hostname "$*" || true
 }
 
-# Get device serial number or unique identifier
-get_device_id() {
+# Validate UUID (accepts with/without dashes, case-insensitive)
+is_valid_uuid() {
+    local v="${1,,}"
+    [[ "$v" =~ ^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ ]]
+}
+
+# Primary source: device UUID
+get_device_uuid() {
+    local uuid=""
+    if [ -r "$UUID_FILE" ]; then
+        uuid="$(tr -d '[:space:]' < "$UUID_FILE" 2>/dev/null || true)"
+    fi
+    echo "$uuid"
+}
+
+# Fallback legacy ID (serial/MAC/machine-id) – used only if UUID is missing/invalid
+get_legacy_id() {
     local device_id=""
-    
-    # Try to get Raspberry Pi serial
+    # Raspberry Pi serial
     if [ -f /proc/cpuinfo ]; then
-        device_id=$(grep Serial /proc/cpuinfo 2>/dev/null | cut -d':' -f2 | tr -d ' ' || true)
+        device_id=$(grep -m1 '^Serial' /proc/cpuinfo 2>/dev/null | cut -d':' -f2 | tr -d ' ' || true)
     fi
-    
-    # If no serial found, try machine-id
+    # machine-id (partial)
     if [ -z "${device_id}" ] && [ -f /etc/machine-id ]; then
-        device_id=$(cat /etc/machine-id | head -c 16)
+        device_id=$(head -c 16 /etc/machine-id || true)
     fi
-    
-    # If still no ID, generate one
+    # first MAC
     if [ -z "${device_id}" ]; then
-        device_id=$(ip link show | grep ether | head -1 | awk '{print $2}' | tr -d ':' | head -c 16)
+        device_id=$(ip link show | awk '/ether/ {gsub(":","",$2); print $2; exit}')
     fi
-    
-    # Fallback to random
+    # random fallback
     if [ -z "${device_id}" ]; then
         device_id=$(tr -dc 'a-f0-9' < /dev/urandom | head -c 16)
     fi
-    
-    echo "${device_id}"
+    echo "$device_id"
 }
 
-# Generate hostname
+# Generate hostname from UUID (preferred) or legacy ID (fallback)
 generate_hostname() {
-    local device_id=$(get_device_id)
-    
-    # Take last 8 characters for readability
-    local short_id="${device_id: -8}"
-    
-    # Convert to lowercase
-    short_id=$(echo "${short_id}" | tr '[:upper:]' '[:lower:]')
-    
-    # Create hostname
-    local hostname="edgeos-${short_id}"
-    
-    echo "${hostname}"
+    local uuid short_id legacy
+    uuid="$(get_device_uuid)"
+
+    if [ -n "$uuid" ] && is_valid_uuid "$uuid"; then
+        uuid="${uuid//-/}"
+        uuid="${uuid,,}"
+        short_id="${uuid: -8}"
+    else
+        legacy="$(get_legacy_id)"
+        legacy="${legacy//-/}"
+        legacy="${legacy,,}"
+        short_id="${legacy: -8}"
+    fi
+
+    echo "${PREFIX}-${short_id}"
 }
 
 # Set hostname
 set_hostname() {
     local new_hostname="$1"
-    local current_hostname=$(hostname)
-    
+    local current_hostname
+    current_hostname=$(hostname || echo "")
+
     if [ "${current_hostname}" = "${new_hostname}" ]; then
         log "Hostname already set to ${new_hostname}"
         return 0
     fi
-    
+
     log "Setting hostname to ${new_hostname}"
-    
-    # Set hostname using hostnamectl if available
+
     if command -v hostnamectl >/dev/null 2>&1; then
         hostnamectl set-hostname "${new_hostname}"
+        echo "${new_hostname}" > /etc/hostname   # menține sincron/compat
     else
-        # Fallback to traditional method
         echo "${new_hostname}" > /etc/hostname
         hostname "${new_hostname}"
     fi
-    
-    # Update /etc/hosts
-    if ! grep -q "${new_hostname}" /etc/hosts; then
-        # Remove old edgeos entries
-        sed -i '/edgeos-/d' /etc/hosts
-        
-        # Add new entry
-        echo "127.0.1.1 ${new_hostname} ${new_hostname}.local" >> /etc/hosts
+
+    # Update /etc/hosts (idempotent)
+    if [ -f /etc/hosts ]; then
+        grep -q "${new_hostname}" /etc/hosts 2>/dev/null || {
+            sed -i '/edgeos-/d' /etc/hosts 2>/dev/null || true
+            echo "127.0.1.1 ${new_hostname} ${new_hostname}.local" >> /etc/hosts
+        }
+    else
+        echo "127.0.1.1 ${new_hostname} ${new_hostname}.local" > /etc/hosts
     fi
-    
+
     log "Hostname set successfully to ${new_hostname}"
 }
 
-# Main execution
 main() {
     log "Starting EdgeOS hostname generation"
-    
-    # Check if we should skip (for development or custom setups)
+
+    # Allow opt-out
     if [ -f /etc/edgeos-hostname-override ]; then
         log "Hostname override found, skipping automatic generation"
         exit 0
     fi
-    
-    # Generate and set hostname
-    local hostname=$(generate_hostname)
-    set_hostname "${hostname}"
-    
-    # Store the generated hostname for reference
-    echo "${hostname}" > /etc/edgeos-hostname
-    
-    # Restart avahi-daemon if it's running to pick up new hostname
-    if systemctl is-active --quiet avahi-daemon.service; then
+
+    mkdir -p "${STATE_DIR}"
+
+    local new
+    new="$(generate_hostname)"
+    set_hostname "${new}"
+
+    echo "${new}" > "${STATE_HOSTNAME_FILE}"
+
+    # Restart avahi-daemon to broadcast the new name via mDNS (if present)
+    if command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet avahi-daemon.service; then
         log "Restarting avahi-daemon to pick up new hostname"
-        systemctl restart avahi-daemon.service
+        systemctl restart avahi-daemon.service || true
     fi
-    
-    log "EdgeOS hostname generation completed"
+
+    log "EdgeOS hostname generation completed: ${new}"
 }
 
-# Run main function
 main "$@"

--- a/meta-edgeos/recipes-core/images/edgeos-image.bb
+++ b/meta-edgeos/recipes-core/images/edgeos-image.bb
@@ -39,3 +39,9 @@ BUILDCFG_VARS += " \
 
 # Disable WIC's automatic fstab updates
 WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
+
+# Provider for 'hostname' required by avahi-daemon
+IMAGE_INSTALL:append = " inetutils-hostname"
+
+# Avahi + the sub-package with the custom script/service
+IMAGE_INSTALL:append = " avahi-daemon avahi-edgeos-hostname"


### PR DESCRIPTION
Updated generate-hostname.sh script to generate hostname from device UUID (with fallback to serial/MAC).

Updated edgeos-hostname.service systemd unit to set and persist hostname at boot.

Updated avahi-daemon.conf automatically with correct defaults (dbus enabled, IPv4/IPv6, reflector, publishing).

Added 90-edgeos.preset to ensure the service is enabled by default on first boot.

Updated edgeos-image.bb to include required runtime packages (inetutils-hostname, avahi-daemon, avahi-edgeos-hostname).